### PR TITLE
Fix severy issues reported by Coverity

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -79,8 +79,8 @@ extern "C"
   long long docker_memory_get_total_pgpgout (
     struct docker_memory_desc *memdesc);
 
-  unsigned int docker_running_containers (const char *image,
-					  char **perfdata, bool verbose);
+  int docker_running_containers (unsigned int *count, const char *image,
+				 char **perfdata, bool verbose);
 
 #ifdef __cplusplus
 }

--- a/lib/container_count.c
+++ b/lib/container_count.c
@@ -192,8 +192,9 @@ docker_close (CURL * curl_handle, chunk_t * chunk)
 
 /* Returns the number of running Docker containers  */
 
-unsigned int
-docker_running_containers (const char *image, char **perfdata, bool verbose)
+int
+docker_running_containers (unsigned int *count, const char *image,
+			   char **perfdata, bool verbose)
 {
   chunk_t chunk;
   hashtable_t *hashtable;
@@ -214,7 +215,9 @@ docker_running_containers (const char *image, char **perfdata, bool verbose)
 
 #else
 
-  docker_get (&chunk, DOCKER_CONTAINERS_JSON);
+  int err;
+  if ((err = docker_get (&chunk, DOCKER_CONTAINERS_JSON)) != 0)
+    return err;
 
 #endif /* NPL_TESTING */
 
@@ -252,13 +255,14 @@ docker_running_containers (const char *image, char **perfdata, bool verbose)
       fclose (stream);
     }
 
-  counter_free (hashtable);
+  *count = running_containers;
 
+  counter_free (hashtable);
   docker_close (
 #ifndef NPL_TESTING
 		 curl_handle,
 #endif
 		 &chunk);
 
-  return running_containers;
+  return 0;
 }

--- a/lib/container_count.c
+++ b/lib/container_count.c
@@ -97,6 +97,7 @@ docker_json_parser (const char *json, const char *token, unsigned long increment
 	}
     }
 
+  free (buffer);
   return hashtable;
 }
 

--- a/lib/container_count.c
+++ b/lib/container_count.c
@@ -93,6 +93,7 @@ docker_json_parser (const char *json, const char *token, unsigned long increment
 	  dbg ("found token \"%s\" with value \"%s\" at position %d\n",
 	       token, value, buffer[i].start);
 	  counter_put (hashtable, value, increment);
+	  free (value);
 	}
     }
 

--- a/plugins/check_docker.c
+++ b/plugins/check_docker.c
@@ -105,7 +105,7 @@ print_version (void)
 int
 main (int argc, char **argv)
 {
-  int c, containers;
+  int c;
   int shift = k_shift;
   bool check_memory = false,
        verbose = false;
@@ -248,12 +248,13 @@ main (int argc, char **argv)
     }
   else
     {
-      containers = docker_running_containers (image, &perfdata_msg, verbose);
+      unsigned int containers;
+      docker_running_containers (&containers, image, &perfdata_msg, verbose);
       status = get_status (containers, my_threshold);
       status_msg = image ?
-       xasprintf ("%s: %d running container(s) of type \"%s\"",
+       xasprintf ("%s: %u running container(s) of type \"%s\"",
                   state_text (status), containers, image) :
-       xasprintf ("%s: %d running container(s)", state_text (status),
+       xasprintf ("%s: %u running container(s)", state_text (status),
                   containers);
     }
 

--- a/tests/testutils.c
+++ b/tests/testutils.c
@@ -74,13 +74,15 @@ test_fstringify (const char * filename)
 
   fseek (stream, 0, SEEK_END);
   if ((size = ftell (stream)) < 0)
-    return NULL;
+    {
+      fclose (stream);
+      return NULL;
+    }
 
   rewind (stream);
 
   buffer = xmalloc ((size_t)size + 1);
-  if (buffer)
-    chars = fread (buffer, 1, (size_t)size, stream);
+  chars = fread (buffer, 1, (size_t)size, stream);
 
   if (ferror (stream) || (chars < (size_t)size))
     {

--- a/tests/testutils.c
+++ b/tests/testutils.c
@@ -72,7 +72,9 @@ test_fstringify (const char * filename)
     return NULL;
 
   fseek (stream, 0, SEEK_END);
-  size = ftell (stream);
+  if ((size = ftell (stream)) < 0)
+    return NULL;
+
   rewind (stream);
 
   buffer = xmalloc (size + 1);
@@ -97,7 +99,7 @@ test_main (int argc, char **argv, int (*func) (void), ...)
   int ret;
 
   va_start (ap, func);
-  while ((lib = va_arg(ap, const char *)))
+ while ((lib = va_arg(ap, const char *)))
     TEST_PRELOAD (lib);
   va_end(ap);
 

--- a/tests/testutils.c
+++ b/tests/testutils.c
@@ -65,7 +65,8 @@ char *
 test_fstringify (const char * filename)
 {
   char * buffer = NULL;
-  size_t size, chars = 0;
+  long size;
+  size_t chars;
   FILE * stream = fopen (filename, "r");
 
   if (NULL == stream)
@@ -77,11 +78,11 @@ test_fstringify (const char * filename)
 
   rewind (stream);
 
-  buffer = xmalloc (size + 1);
+  buffer = xmalloc ((size_t)size + 1);
   if (buffer)
-    chars = fread (buffer, 1, size, stream);
+    chars = fread (buffer, 1, (size_t)size, stream);
 
-  if (ferror (stream) || (chars < size))
+  if (ferror (stream) || (chars < (size_t)size))
     {
       free (buffer);
       buffer = NULL;

--- a/tests/tslibcontainer_count.c
+++ b/tests/tslibcontainer_count.c
@@ -46,9 +46,6 @@ docker_get (chunk_t * chunk, const int query)
 	break;
     }
 
-  if (NULL == filename)
-    return EXIT_AM_HARDFAIL;
-
   chunk->memory = test_fstringify (filename);
   if (NULL == chunk->memory)
     return EXIT_AM_HARDFAIL;

--- a/tests/tslibcontainer_count.c
+++ b/tests/tslibcontainer_count.c
@@ -48,7 +48,11 @@ docker_get (chunk_t * chunk, const int query)
 
   if (NULL == filename)
     return EXIT_AM_HARDFAIL;
+
   chunk->memory = test_fstringify (filename);
+  if (NULL == chunk->memory)
+    return EXIT_AM_HARDFAIL;
+
   chunk->size = strlen (chunk->memory);
 
   return 0;

--- a/tests/tsliburlencode.c
+++ b/tests/tsliburlencode.c
@@ -39,8 +39,10 @@ test_url_encoding (const void *tdata)
 {
   const struct test_data *data = tdata;
   int ret = 0;
+  char *encoded_url = url_encode (data->url);
 
-  TEST_ASSERT_EQUAL_STRING (url_encode (data->url), data->expect_value);
+  TEST_ASSERT_EQUAL_STRING (encoded_url, data->expect_value);
+  free (encoded_url);
   return ret;
 }
 

--- a/tests/tststestutils.c
+++ b/tests/tststestutils.c
@@ -35,6 +35,8 @@ test_fstringify_bufsize (const void *tdata)
   const struct test_data *data = tdata;
 
   char * buffer = test_fstringify (data->filename);
+  if (NULL == buffer)
+    return -1;
 
   TEST_ASSERT_EQUAL_NUMERIC (data->expect_size, strlen (buffer));
 


### PR DESCRIPTION
of the following types:
 * argument cannot be negative;
 * explicit null dereference count;
 * less-than-zero comparison of an unsigned value is never true;
 * logically daed code;
 * resource leak.

mainly in the tests folder but also in lib/container_count.c