### PR TITLE
build: fix unsupported warning options for clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,7 @@ dnl Checks for some compiler warning flags
 
 cc_TRY_CFLAGS([-Wall])
 cc_TRY_CFLAGS([-Wformat])
-cc_TRY_CFLAGS([-Wformat-security])
+cc_TRY_CFLAGS([-Wformat -Wformat-security])
 cc_TRY_CFLAGS([-Wformat-signedness])
 cc_TRY_CFLAGS([-Wmissing-noreturn])
 cc_TRY_CFLAGS([-Wmissing-format-attribute])

--- a/m4/cc_try_cflags.m4
+++ b/m4/cc_try_cflags.m4
@@ -23,9 +23,9 @@ dnl If supported, the current CFLAGS is appended to SUPPORTED_CFLAGS
 AC_DEFUN([cc_TRY_CFLAGS],
    [AC_MSG_CHECKING([whether compiler accepts $1])
    ac_save_CFLAGS="$CFLAGS"
-   CFLAGS="$CFLAGS $1"
+   CFLAGS="$CFLAGS -Werror $1"
    AC_COMPILE_IFELSE(
-     [AC_LANG_PROGRAM([[]],[[int x;]])],
+     [AC_LANG_PROGRAM([[]],[[]])],
      [AC_MSG_RESULT([yes])
       SUPPORTED_CFLAGS="$SUPPORTED_CFLAGS $1"],
      [AC_MSG_RESULT([no])]


### PR DESCRIPTION
Compiling the source code with clang (7.0.0) two annoying
warning messages are printed at each compiler invocation:

    warning: unknown warning option '-Wformat-signedness' [-Wunknown-warning-option]
    warning: unknown warning option '-Wstringop-truncation'; did you mean '-Wstring-conversion'? [-Wunknown-warning-option]

Modify the m4 `macro cc_try_cflags' to fix this issue.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>