### PR TITLE
Fix two security issues reported by lgtm analyzer

### DIFF
--- a/plugins/check_clock.c
+++ b/plugins/check_clock.c
@@ -89,15 +89,15 @@ print_version (void)
 static int
 get_timedelta (unsigned long refclock, bool verbose)
 {
-  struct tm *tm;
-  time_t t;
+  struct tm tminfo;
+  time_t rawtime;
   char outstr[32];
   char *end = NULL;
   long timedelta;
 
-  t = time (NULL);
-  tm = localtime (&t);
-  if (strftime (outstr, sizeof (outstr), "%s", tm) == 0)
+  rawtime = time (NULL);
+  localtime_r (&rawtime, &tminfo);
+  if (strftime (outstr, sizeof (outstr), "%s", &tminfo) == 0)
     plugin_error (STATE_UNKNOWN, errno, "strftime() failed");
 
   timedelta = (strtol (outstr, &end, 10) - refclock);

--- a/plugins/check_users.c
+++ b/plugins/check_users.c
@@ -126,10 +126,11 @@ main (int argc, char **argv)
 	  numuser++;
 	  if (!verbose)
 	    continue;
+	  char buf[26];
 	  time_t timetmp = ut->ut_tv.tv_sec;
 	  printf ("%-8s %5ld %-6.6s %-9.9s %s", ut->ut_user,
 		  (long) ut->ut_pid, ut->ut_line, ut->ut_host,
-		  ctime (&timetmp));
+		  ctime_r (&timetmp, buf));
 	}
     }
   endutxent ();


### PR DESCRIPTION
Fix two issues reported by the lgtm code analyser:
 - Call to **localtime** is potentially dangerous (plugins/check_clock.c)
 - Call to **ctime** is potentially dangerous (plugins/check_users.c)

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>