### PR TITLE
Make rpm packages for Fedora 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ This package is known to compile with:
 * gcc 4.1.2 (RHEL 5 / CentOS 5),
 * gcc 4.4 (RHEL6 / CentOS 6),
 * gcc 4.8.2 (RHEL7 / CentOS 7),
-* gcc 5.1.1, 5.3.1, 6.3.1, 7.2.1, 7.3.1, 8.0.1, 8.2.1 (Fedora 23 Cloud, Fedora 25 to 29),
-* clang 3.7.0, 3.8.0, 5.0.1, 6.0.0, 7.0.0 (Fedora 23 Cloud, Fedora 25 to 29),
+* gcc 5.1.1, 5.3.1, 6.3.1, 7.2.1, 7.3.1, 8.0.1, 8.2.1, 9.1.1 (Fedora 23 Cloud, Fedora 25 to 30),
+* clang 3.7.0, 3.8.0, 5.0.1, 6.0.0, 7.0.0, 8.0.0 (Fedora 23 Cloud, Fedora 25 to 30),
 * gcc 4.9.0-4.9.2, 5.2.0, 5.3.0, 6.2.0 (openmamba GNU/Linux 2.90+),
 * clang 3.1, 3.5.1, and 3.8.1 (openmamba GNU/Linux 2.90+).
 
@@ -133,6 +133,7 @@ Fedora 26          | `make -C packages fedora-26`
 Fedora 27          | `make -C packages fedora-27`
 Fedora 28          | `make -C packages fedora-28`
 Fedora 29          | `make -C packages fedora-29`
+Fedora 30          | `make -C packages fedora-30`
 Fedora Rawhide     | `make -C packages fedora-rawhide`
 
 in the root source folder.

--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -35,11 +35,12 @@ MULTIBUILD_OPTS = \
 
 TARGETS_REDHAT = \
 	centos-5 centos-6 centos-7 \
-	fedora-24 fedora-25 fedora-26 fedora-27 fedora-28 fedora-29 \
+	fedora-24 fedora-25 fedora-26 fedora-27 \
+	fedora-28 fedora-29 fedora-30 \
 	fedora-rawhide
 
 centos-latest: centos-7
-fedora-latest: fedora-29
+fedora-latest: fedora-30
 
 TARGETS_DEBIAN = debian-squeeze debian-wheezy debian-jessie debian-stretch
 


### PR DESCRIPTION
The `make -C packages command` does not support Fedora 30.
Add a make target for such a Linux distribution and make `fedora-latest` and alias for Fedora 30. 

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>