### PR TITLE
Fix an issue reported by the clang static analyser v8

### DIFF
--- a/tests/tslibcontainer_count.c
+++ b/tests/tslibcontainer_count.c
@@ -74,7 +74,7 @@ test_docker_running_containers (const void *tdata)
 {
   const struct test_data *data = tdata;
   int err, ret = 0;
-  char * perfdata;
+  char * perfdata = NULL;
   unsigned int containers;
 
   err = docker_running_containers (&containers, data->image, &perfdata, false);


### PR DESCRIPTION
Fix the following issue reported by the clang static analyser v8:
```
tslibcontainer_count.c:83:7: warning: 1st function call argument is an uninitialized value
      free (perfdata);
      ^~~~~~~~~~~~~~~
```
Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>