### PR TITLE
check_memory: add perfdata to mem_available and mem_used

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -34,6 +34,7 @@ noinst_HEADERS = \
 	mountlist.h \
 	messages.h \
 	netinfo.h \
+	perfdata.h \
 	processes.h \
 	procparser.h \
 	progname.h \

--- a/include/meminfo.h
+++ b/include/meminfo.h
@@ -18,11 +18,6 @@
 
 #include "system.h"
 
-#define max(a,b) \
-  ({ __typeof__ (a) _a = (a); \
-     __typeof__ (b) _b = (b); \
-     _a > _b ? _a : _b; })
-
 #ifdef __cplusplus
 extern "C"
 {

--- a/include/meminfo.h
+++ b/include/meminfo.h
@@ -18,6 +18,11 @@
 
 #include "system.h"
 
+#define max(a,b) \
+  ({ __typeof__ (a) _a = (a); \
+     __typeof__ (b) _b = (b); \
+     _a > _b ? _a : _b; })
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/include/perfdata.h
+++ b/include/perfdata.h
@@ -1,0 +1,37 @@
+/* perfdata.h -- a library for managing the Nagios perfdata
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef _PERFDATA_H_
+#define _PERFDATA_H_
+
+#include "system.h"
+#include "thresholds.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  int get_perfdata_limit (range * threshold, unsigned long base,
+			  unsigned long long *limit, bool percent);
+  int get_perfdata_limit_converted (range * threshold, unsigned long base,
+				    int shift, unsigned long long *limit,
+				    bool percent);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif				/* _PERFDATA_H_ */

--- a/include/string-macros.h
+++ b/include/string-macros.h
@@ -16,6 +16,7 @@
 #ifndef _STRING_MACROS_H
 # define _STRING_MACROS_H     1
 
+# define STRCONTAINS(a, b) (NULL != strpbrk(a, b))
 # define STREQ(a, b) (strcmp(a, b) == 0)
 # define STRNEQ(a, b) (strcmp(a, b) != 0)
 # define STREQLEN(a, b, n) (strncmp(a, b, n) == 0)

--- a/include/thresholds.h
+++ b/include/thresholds.h
@@ -21,6 +21,9 @@
 #define NP_RANGE_UNPARSEABLE 1
 #define NP_WARN_WITHIN_CRIT  2
 
+#define NP_RANGE_OUTSIDE 0
+#define NP_RANGE_INSIDE  1
+
 /* see: nagios-plugins-1.4.15/lib/utils_base.h */
 typedef struct range_struct
 {
@@ -39,3 +42,5 @@ typedef struct thresholds_struct
 
 int get_status (double, thresholds *);
 int set_thresholds (thresholds **, char *, char *);
+bool thresholds_expressed_as_percentages (char *warn_string,
+					  char *critical_string);

--- a/include/thresholds.h
+++ b/include/thresholds.h
@@ -29,9 +29,9 @@ typedef struct range_struct
 {
   double start;
   double end;
-  bool start_infinity;		/* false (default) or true */
+  bool start_infinity;	/* false (default) or true */
   bool end_infinity;
-  int alert_on;			/* OUTSIDE (default) or INSIDE */
+  int alert_on;		/* NP_RANGE_OUTSIDE (default) or NP_RANGE_INSIDE */
 } range;
 
 typedef struct thresholds_struct

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -36,6 +36,7 @@ libutils_a_SOURCES =  \
 	messages.c    \
 	mountlist.c   \
 	netinfo.c     \
+	perfdata.c    \
 	processes.c   \
 	procparser.c  \
 	progname.c    \

--- a/lib/perfdata.c
+++ b/lib/perfdata.c
@@ -1,0 +1,86 @@
+/*
+ * License: GPLv3+
+ * Copyright (c) 2019 Davide Madrisan <davide.madrisan@gmail.com>
+ *
+ * A library to manage the Nagios perfdata.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * This software takes some ideas and code from procps-3.2.8 (free).
+ */
+
+#include "common.h"
+#include "logging.h"
+#include "system.h"
+#include "thresholds.h"
+#include "units.h"
+
+int
+get_perfdata_limit (range * threshold, unsigned long base,
+		    unsigned long long *limit, bool percent)
+{
+  if (NULL == threshold)
+    return -1;
+
+  double threshold_limit;
+
+  if (NP_RANGE_INSIDE == threshold->alert_on)
+    {
+      /* example: @10:20  >= 10 and <= 20, (inside the range of {10 .. 20}) */
+      dbg ("threshold {%g, %g} with alert_on set to true\n",
+	   threshold->start, threshold->end);
+      return -1;
+    }
+  else if (threshold->start_infinity)
+    {
+      /* example: ~:10    > 10, (outside the range of {-\infty .. 10}) */
+      dbg ("threshold {%g, %g} with start_infinity set to true\n",
+	   threshold->start, threshold->end);
+      return -1;
+    }
+  else if (threshold->end_infinity)
+    {
+      /* example: 10:     < 10, (outside {10 .. \infty}) */
+      dbg ("threshold {%g, %g} with end_infinity set to true\n",
+	   threshold->start, threshold->end);
+      threshold_limit = threshold->start;
+    }
+  else
+    {
+      /* example: 10      < 0 or > 10, (outside the range of {0 .. 10})
+       *          ~:10    > 10, (outside the range of {-\infty .. 10}) */
+      dbg ("threshold {%g, %g}\n",
+	   threshold->start, threshold->end);
+      threshold_limit = threshold->end;
+  }
+
+  *limit = (unsigned long long) (base * threshold_limit);
+  if (percent)
+    *limit = (unsigned long long) (*limit / 100.0);
+
+  return 0;
+}
+
+int
+get_perfdata_limit_converted (range * threshold, unsigned long base, int shift,
+			      unsigned long long *limit, bool percent)
+{
+  int error = get_perfdata_limit (threshold, base, limit, percent);
+  if (0 != error)
+    return error;
+
+  *limit = UNIT_CONVERT (*limit, shift);
+  return 0;
+
+}

--- a/lib/thresholds.c
+++ b/lib/thresholds.c
@@ -160,7 +160,7 @@ parse_range_string (char *str)
 }
 
 /*
- * returns 0 if okay, otherwise 1 
+ * Returns 0 if okay, otherwise 1 (NP_RANGE_UNPARSEABLE)
  */
 int
 set_thresholds (thresholds ** my_thresholds, char *warn_string,

--- a/lib/thresholds.c
+++ b/lib/thresholds.c
@@ -30,9 +30,6 @@
 #include "thresholds.h"
 #include "xalloc.h"
 
-#define OUTSIDE 0
-#define INSIDE  1
-
 /*
  * Returns TRUE if alert should be raised based on the range 
  */
@@ -42,7 +39,7 @@ check_range (double value, range * my_range)
   bool no = false;
   bool yes = true;
 
-  if (my_range->alert_on == INSIDE)
+  if (my_range->alert_on == NP_RANGE_INSIDE)
     {
       no = true;
       yes = false;
@@ -121,11 +118,11 @@ parse_range_string (char *str)
   temp_range->start_infinity = false;
   temp_range->end = 0;
   temp_range->end_infinity = true;
-  temp_range->alert_on = OUTSIDE;
+  temp_range->alert_on = NP_RANGE_OUTSIDE;
 
   if (str[0] == '@')
     {
-      temp_range->alert_on = INSIDE;
+      temp_range->alert_on = NP_RANGE_INSIDE;
       str++;
     }
 
@@ -199,4 +196,19 @@ set_thresholds (thresholds ** my_thresholds, char *warn_string,
   *my_thresholds = temp_thresholds;
 
   return 0;
+}
+
+/*
+ * Returns true if the warning and critical thresholds are expressed
+ * as percentages (when defined), false otherwise
+ */
+
+bool
+thresholds_expressed_as_percentages (char *warn_string, char *critical_string)
+{
+  if ((warn_string && !STRCONTAINS (warn_string, "%"))
+      || (critical_string && !STRCONTAINS (critical_string, "%")))
+    return false;
+
+  return true;
 }

--- a/plugins/check_memory.c
+++ b/plugins/check_memory.c
@@ -30,6 +30,7 @@
 #include "logging.h"
 #include "meminfo.h"
 #include "messages.h"
+#include "perfdata.h"
 #include "progname.h"
 #include "progversion.h"
 #include "system.h"
@@ -102,65 +103,6 @@ print_version (void)
   fputs (GPLv3_DISCLAIMER, stdout);
 
   exit (STATE_OK);
-}
-
-static int
-get_perfdata_limit (range * threshold, unsigned long base,
-		    unsigned long long *limit, bool percent)
-{
-  if (NULL == threshold)
-    return -1;
-
-  double threshold_limit;
-
-  if (NP_RANGE_INSIDE == threshold->alert_on)
-    {
-      /* example: @10:20  >= 10 and <= 20, (inside the range of {10 .. 20}) */
-      dbg ("threshold {%g, %g} with alert_on set to true\n",
-	   threshold->start, threshold->end);
-      return -1;
-    }
-  else if (threshold->start_infinity)
-    {
-      /* example: ~:10    > 10, (outside the range of {-\infty .. 10}) */
-      dbg ("threshold {%g, %g} with start_infinity set to true\n",
-	   threshold->start, threshold->end);
-      return -1;
-    }
-  else if (threshold->end_infinity)
-    {
-      /* example: 10:     < 10, (outside {10 .. \infty}) */
-      dbg ("threshold {%g, %g} with end_infinity set to true\n",
-	   threshold->start, threshold->end);
-      threshold_limit = threshold->start;
-    }
-  else
-    {
-      /* example: 10      < 0 or > 10, (outside the range of {0 .. 10})
-       *          ~:10    > 10, (outside the range of {-\infty .. 10}) */
-      dbg ("threshold {%g, %g}\n",
-	   threshold->start, threshold->end);
-      threshold_limit = threshold->end;
-  }
-
-  *limit = (unsigned long long) (base * threshold_limit);
-  if (percent)
-    *limit = (unsigned long long) (*limit / 100.0);
-
-  return 0;
-}
-
-static int
-get_perfdata_limit_converted (range * threshold, unsigned long base, int shift,
-			      unsigned long long *limit, bool percent)
-{
-  int error = get_perfdata_limit (threshold, base, limit, percent);
-  if (0 != error)
-    return error;
-
-  *limit = UNIT_CONVERT (*limit, shift);
-  return 0;
-
 }
 
 #ifndef NPL_TESTING

--- a/plugins/check_memory.c
+++ b/plugins/check_memory.c
@@ -268,7 +268,7 @@ main (int argc, char **argv)
    * 'label'=value[UOM];[warn];[crit];[min];[max] */
   bool add_perfdata = (kb_mem_monitored == &kb_mem_main_available);
   perfdata_memavailable_msg =
-    xasprintf ("mem_available=%llu%s;%s;%s;0;%llu",
+    xasprintf ("mem_available=%llu%s;%s;%s;0;%llu;",
 	       UNIT_STR (kb_mem_main_available),
 	       (add_perfdata
 	        && mem_monitored_warning) ? mem_monitored_warning : "",
@@ -278,7 +278,7 @@ main (int argc, char **argv)
 
   add_perfdata = (kb_mem_monitored == &kb_mem_main_used);
   perfdata_memused_msg =
-    xasprintf ("mem_used=%llu%s;%s;%s;0;%llu",
+    xasprintf ("mem_used=%llu%s;%s;%s;0;%llu;",
 	       UNIT_STR (kb_mem_main_used),
 	       (add_perfdata
 		&& mem_monitored_warning) ? mem_monitored_warning : "",

--- a/plugins/check_memory.c
+++ b/plugins/check_memory.c
@@ -31,6 +31,7 @@
 #include "messages.h"
 #include "progname.h"
 #include "progversion.h"
+#include "system.h"
 #include "thresholds.h"
 #include "units.h"
 #include "vminfo.h"
@@ -250,36 +251,39 @@ main (int argc, char **argv)
     {
       double warning_threshold = max (my_threshold->warning->start,
 				      my_threshold->warning->end);
-      unsigned long mem_amount =
+      unsigned long long mem_amount =
 	UNIT_CONVERT (kb_mem_main_total * warning_threshold / 100.0, shift);
-      mem_monitored_warning = xasprintf ("%lu", mem_amount);
+      mem_monitored_warning = xasprintf ("%llu", mem_amount);
     }
   if (my_threshold->critical)
     {
       double critical_threshold = max (my_threshold->critical->start,
 				       my_threshold->critical->end);
-      unsigned long mem_amount =
+      unsigned long long mem_amount =
 	UNIT_CONVERT (kb_mem_main_total * critical_threshold / 100.0, shift);
-      mem_monitored_critical = xasprintf ("%lu", mem_amount);
+      mem_monitored_critical = xasprintf ("%llu", mem_amount);
     }
 
   /* performance data format:
    * 'label'=value[UOM];[warn];[crit];[min];[max] */
+  bool add_perfdata = (kb_mem_monitored == &kb_mem_main_available);
   perfdata_memavailable_msg =
     xasprintf ("mem_available=%llu%s;%s;%s;0;%llu",
 	       UNIT_STR (kb_mem_main_available),
-	       (kb_mem_monitored == &kb_mem_main_available
+	       (add_perfdata
 	        && mem_monitored_warning) ? mem_monitored_warning : "",
-	       (kb_mem_monitored == &kb_mem_main_available
+	       (add_perfdata
 	        && mem_monitored_critical) ? mem_monitored_critical : "",
 	       UNIT_CONVERT (kb_mem_main_total, shift));
+
+  add_perfdata = (kb_mem_monitored == &kb_mem_main_used);
   perfdata_memused_msg =
     xasprintf ("mem_used=%llu%s;%s;%s;0;%llu",
 	       UNIT_STR (kb_mem_main_used),
-	       (kb_mem_monitored == &kb_mem_main_used
-	        && mem_monitored_warning) ? mem_monitored_warning : "",
-	       (kb_mem_monitored == &kb_mem_main_used
-	        && mem_monitored_critical) ? mem_monitored_critical : "",
+	       (add_perfdata
+		&& mem_monitored_warning) ? mem_monitored_warning : "",
+	       (add_perfdata &&
+		mem_monitored_critical) ? mem_monitored_critical : "",
 	       UNIT_CONVERT (kb_mem_main_total, shift));
 
   status_msg =


### PR DESCRIPTION
Add min, max, warning and critical in perfdata for mem_available
and mem_used as asked by sbraz (issue #32).

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>