### PR TITLE
packages: support build of rpm packages for CentOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Command            | Distribution
 CentOS 5           | `make -C packages centos-5`
 CentOS 6           | `make -C packages centos-6`
 CentOS 7           | `make -C packages centos-7`
+CentOS 8           | `make -C packages centos-8`
 Debian 8 (Jessie)  | `make -C packages debian-jessie`
 Debian 9 (Stretch) | `make -C packages debian-stretch`
 Debian 10 (Buster) | `make -C packages debian-buster`

--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -33,11 +33,11 @@ MULTIBUILD_OPTS = \
 	--pckver $(PACKAGE_VERSION)
 
 TARGETS_REDHAT = \
-	centos-5 centos-6 centos-7 \
+	centos-5 centos-6 centos-7 centos-8 \
 	fedora-28 fedora-29 fedora-30 \
 	fedora-rawhide
 
-centos-latest: centos-7
+centos-latest: centos-8
 fedora-latest: fedora-30
 
 TARGETS_DEBIAN = \

--- a/packages/multibuild.sh
+++ b/packages/multibuild.sh
@@ -135,7 +135,8 @@ case "$os" in
       pck_dist=".el${os:7:1}"
       pcks_dev="bzip2 make gcc libcurl-devel xz rpm-build"
       # requires libcurl-devel 7.40.0+ which is not available in < CentOS 8
-      have_libcurl="0" ;;
+      case "$os" in centos-8.*) have_libcurl="1" ;; *) have_libcurl="0" ;; esac
+   ;;
    debian-*)
       pck_format="deb"
       pck_install="\
@@ -159,6 +160,13 @@ pckname="nagios-plugins-linux"
 echo "\
 Container \"$container\"  status:running  ipaddr:$ipaddr  os:$os
 "
+
+if [ "$have_libcurl" = "0" ]; then
+   msg "the docker plugin will not be built because libcurl is too old."
+else
+   msg "the available curl library allows the docker plugin to be built."
+fi
+
 msg "testing the build process inside $container ..."
 container_exec_command "$container" "\
 # fixes for debian 6 (squeeze)


### PR DESCRIPTION
Now that the Docker image for CentOS 8 is available,
the build of the packages for this OS should can be added.

Add a new makefile target for this OS: `centos-8`

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>