### PR TITLE
The build fails when '-fno-common' is added to CFLAGS

### DIFF
--- a/include/progname.h
+++ b/include/progname.h
@@ -25,10 +25,10 @@ extern "C" {
 #endif
 
   /* String containing name the program is called with.  */
-  const char *program_name;
+  extern const char *program_name;
 
   /* String containing a short version of 'program_name'.  */
-  const char *program_name_short;
+  extern const char *program_name_short;
 
   /* Set program_name, based on argv[0].
      argv0 must be a string allocated with indefinite extent, and must not be


### PR DESCRIPTION
As reported by 'sbraz', the build stops with the error message:

   (.bss+0x8): multiple definition of `program_name'
   (.bss+0x0): multiple definition of `program_name_short'

This flag will be apparently enabled by default in gcc 10.

Fix this build problem by correctly referencing as extern both
the variables in the header file.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>