### PR TITLE
Fix build with musl by including limits.h when PATH_MAX is used

### DIFF
--- a/lib/processes.c
+++ b/lib/processes.c
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
+#include <limits.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/plugins/check_fc.c
+++ b/plugins/check_fc.c
@@ -22,6 +22,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <getopt.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Hi Davide,
Here is another patch for a build problem. Initially reported at https://bugs.gentoo.org/717038

Without these includes, the build fails with musl:
``` 
error: PATH_MAX undeclared (first use in this function)
```