### PR TITLE
Fix build linked to the procps-ng newlib library

### DIFF
--- a/lib/meminfo_procps.c
+++ b/lib/meminfo_procps.c
@@ -22,7 +22,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
-#include <proc/procps.h>
+#include <proc/meminfo.h>
 
 typedef struct proc_sysmem
 {

--- a/lib/vminfo_procps.c
+++ b/lib/vminfo_procps.c
@@ -111,14 +111,7 @@ proc_vmem_get_pgsteal (struct proc_vmem *vmem)
   if (vmem == NULL)
     return 0;
 
-  unsigned long vm_pgsteal_direct_dma = GET_DATA (VMSTAT_PGSTEAL_DIRECT_DMA);
-  unsigned long vm_pgsteal_direct_dma32 =
-    GET_DATA (VMSTAT_PGSTEAL_DIRECT_DMA32);
-  unsigned long vm_pgsteal_direct_normal =
-    GET_DATA (VMSTAT_PGSTEAL_DIRECT_NORMAL);
-
-  return vm_pgsteal_direct_dma +
-    vm_pgsteal_direct_dma32 + vm_pgsteal_direct_normal;
+  return GET_DATA (VMSTAT_PGSTEAL_DIRECT);
 }
 
 unsigned long
@@ -127,14 +120,7 @@ proc_vmem_get_pgscand (struct proc_vmem *vmem)
   if (vmem == NULL)
     return 0;
 
-  unsigned long vm_pgscan_direct_dma = GET_DATA (VMSTAT_PGSCAN_DIRECT_DMA);
-  unsigned long vm_pgscan_direct_dma32 =
-    GET_DATA (VMSTAT_PGSCAN_DIRECT_DMA32);
-  unsigned long vm_pgscan_direct_normal =
-    GET_DATA (VMSTAT_PGSCAN_DIRECT_NORMAL);
-
-  return vm_pgscan_direct_dma +
-    vm_pgscan_direct_dma32 + vm_pgscan_direct_normal;
+  return GET_DATA (VMSTAT_PGSCAN_DIRECT);
 }
 
 unsigned long
@@ -143,14 +129,7 @@ proc_vmem_get_pgscank (struct proc_vmem *vmem)
   if (vmem == NULL)
     return 0;
 
-  unsigned long vm_pgscan_kswapd_dma = GET_DATA (VMSTAT_PGSCAN_KSWAPD_DMA);
-  unsigned long vm_pgscan_kswapd_dma32 =
-    GET_DATA (VMSTAT_PGSCAN_KSWAPD_DMA32);
-  unsigned long vm_pgscan_kswapd_normal =
-    GET_DATA (VMSTAT_PGSCAN_KSWAPD_NORMAL);
-
-  return vm_pgscan_kswapd_dma +
-    vm_pgscan_kswapd_dma32 + vm_pgscan_kswapd_normal;
+  return GET_DATA (VMSTAT_PGSCAN_KSWAPD);
 }
 
 #undef GET_DATA

--- a/lib/vminfo_procps.c
+++ b/lib/vminfo_procps.c
@@ -22,7 +22,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
-#include <proc/procps.h>
+#include <proc/vmstat.h>
 
 typedef struct proc_vmem
 {

--- a/tests/tslibmeminfo_interface.c
+++ b/tests/tslibmeminfo_interface.c
@@ -21,7 +21,7 @@
 
 #include "testutils.h"
 
-#ifdef PROC_MEMINFO
+#if defined (PROC_MEMINFO) && !defined (HAVE_LIBPROCPS)
 
 # define NPL_TESTING
 #  include "../lib/meminfo.c"
@@ -135,4 +135,4 @@ main (void)
   return EXIT_AM_SKIP;
 }
 
-#endif		/* PROC_MEMINFO */
+#endif


### PR DESCRIPTION
Fix the build when '--enable-libprocps' is passed to configure.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>