### PR TITLE
Add everywhere the SPDX License Identifiers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,7 +5,8 @@ External libraries:
    Jsmn (pronounced like 'jasmine'), a world fastest JSON parser/tokenizer
      * Author: Serge Zaitsev
      * Git repository: https://github.com/zserge/jsmn
-     * Files: include/json.h
+     * Files: include/jsmn.h
+     * SPDX-License-Identifier: MIT
 
 Contributors:
    flexdev - https://github.com/flexdev
@@ -16,33 +17,33 @@ Contributors:
 Some code and coding styles/ideas belong to the following open source projects:
 
  * cpufrequtils    https://www.kernel.org/pub/linux/utils/kernel/cpufreq/
-                   License: GPLv2
+                   SPDX-License-Identifier: GPL-2.0-only
 
  * gnulib          http://git.savannah.gnu.org/gitweb/?p=gnulib.git
-                   License: GPLv2
+                   SPDX-License-Identifier: GPL-3.0-or-later / LGPL-3.0-or-later
 
  * kmod            http://git.kernel.org/cgit/utils/kernel/kmod/kmod.git
-                   License: GPLv2
+                   SPDX-License-Identifier: GPL-2.0-only
 
  * libabc          https://git.kernel.org/cgit/linux/kernel/git/kay/libabc.git
-                   License: LGPLv2 (with an unrestricted usage clause)
+                   SPDX-License-Identifier: GPL-2.0-only (with an unrestricted usage clause)
 
  * libvirt         http://libvirt.org/
-                   License: GPLv2, LGPLv2
+                   SPDX-License-Identifier: GPL-2.1-only / LGPL-2.1-only
 
  * nagios plugins  https://github.com/nagios-plugins/nagios-plugins
-                   License: GPLv3
+                   SPDX-License-Identifier: GPL-3.0-or-later
 
- * procps          https://gitorious.org/procps
-                   License: GPLv2, LGPLv2 (libprocps)
+ * procps          https://gitlab.com/procps-ng/procps/
+                   SPDX-License-Identifier: GPL-2.0-only / LGPL-2.0-only (libprocps)
 
  * util-linux      https://github.com/karelzak/util-linux
-                   License: GPLv2
+                   SPDX-License-Identifier: GPL-2.0-only
 
  * pcp             https://github.com/performancecopilot/pcp
-                   License: LGPLv2.1+
+                   SPDX-License-Identifier: LGPL-2.1-or-later
 
 and also to Mickael Kerrisk of "The Linux Programming Interface":
 
  * tlpi            http://man7.org/tlpi/code/
-                   License: GNU Affero GPLv3
+                   SPDX-License-Identifier: AGPL-3.0

--- a/check_skel.c.sample
+++ b/check_skel.c.sample
@@ -1,6 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
- * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>
+ * Copyright (c) 2020 Davide Madrisan <davide.madrisan@gmail.com>
  *
  * A Nagios plugin that do something ....
  *
@@ -30,7 +31,7 @@
 #include "thresholds.h"
 
 static const char *program_copyright =
-  "Copyright (C) 2014 Davide Madrisan <" PACKAGE_BUGREPORT ">\n";
+  "Copyright (C) 2020 Davide Madrisan <" PACKAGE_BUGREPORT ">\n";
 
 static struct option const longopts[] = {
   {(char *) "critical", required_argument, NULL, 'c'},

--- a/include/collection.h
+++ b/include/collection.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*  collection.h -- dictionary for counting hashable objects (strings)
 
     This program is free software: you can redistribute it and/or modify

--- a/include/common.h
+++ b/include/common.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* common.h -- set of common macros and definitions
 
    This program is free software: you can redistribute it and/or modify
@@ -18,7 +19,8 @@
 
 #define GPLv3_DISCLAIMER \
   "\
-License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\
+License (SPDX ID): GPL-3.0-or-later \
+<https://www.gnu.org/licenses/gpl.html>\n\
 This is free software; you are free to change and redistribute it.\n\
 There is NO WARRANTY, to the extent permitted by law.\n"
 

--- a/include/container_docker.h
+++ b/include/container_docker.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* container_docker.h -- a library for checking sysfs for Docker exposed metrics
 
    This program is free software: you can redistribute it and/or modify

--- a/include/container_podman.h
+++ b/include/container_podman.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* container_podman.h -- a library for checking Podman containes via varlink
 
    This program is free software: you can redistribute it and/or modify

--- a/include/cpudesc.h
+++ b/include/cpudesc.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* cpudesc.h -- a library for checking the CPU features
 
    This program is free software: you can redistribute it and/or modify

--- a/include/cpufreq.h
+++ b/include/cpufreq.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* cpufreq.h -- a library for checking the CPU frequency configuration
 
    This program is free software: you can redistribute it and/or modify

--- a/include/cpustats.h
+++ b/include/cpustats.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* cpustats.h -- a library for checking the CPU utilization
 
    This program is free software: you can redistribute it and/or modify

--- a/include/cputopology.h
+++ b/include/cputopology.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* cputopology.h -- a library for checking the CPU topology
 
    This program is free software: you can redistribute it and/or modify

--- a/include/getenv.h
+++ b/include/getenv.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* getenv.h -- this header file just provides an alias for getenv_secure ()
 
    This program is free software: you can redistribute it and/or modify

--- a/include/interrupts.h
+++ b/include/interrupts.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* interrupts.h -- a library for checking the system interrupts
 
    This program is free software: you can redistribute it and/or modify

--- a/include/jsmn.h
+++ b/include/jsmn.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
  * MIT License
  *

--- a/include/json_helpers.h
+++ b/include/json_helpers.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* json_helpers.h -- Helper function for parsing data in JSON format
 
    This program is free software: you can redistribute it and/or modify

--- a/include/kernelver.h
+++ b/include/kernelver.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*  kernelver.h -- get the version of a running Linux kernel
 
     This program is free software: you can redistribute it and/or modify

--- a/include/logging.h
+++ b/include/logging.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*  logging.h -- logging facilities
 
     This program is free software: you can redistribute it and/or modify

--- a/include/meminfo.h
+++ b/include/meminfo.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* meminfo.h -- a library for getting system memory informations
 
    This program is free software: you can redistribute it and/or modify

--- a/include/messages.h
+++ b/include/messages.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* messages.h -- a library for uniform output and error messages
 
    This program is free software: you can redistribute it and/or modify

--- a/include/mountlist.h
+++ b/include/mountlist.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* mountlist.h -- a library for getting informations about filesystems
 
    This program is free software: you can redistribute it and/or modify

--- a/include/netinfo.h
+++ b/include/netinfo.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* netinfo.h -- a library foe getting network interfaces statistics
 
    This program is free software: you can redistribute it and/or modify

--- a/include/perfdata.h
+++ b/include/perfdata.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* perfdata.h -- a library for managing the Nagios perfdata
 
    This program is free software: you can redistribute it and/or modify

--- a/include/processes.h
+++ b/include/processes.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* processes.h -- get informations about running processes
 
    This program is free software: you can redistribute it and/or modify

--- a/include/procparser.h
+++ b/include/procparser.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* procparser.h -- a parser for /proc files, /proc/meminfo, and /proc/vmstat
 
    This program is free software: you can redistribute it and/or modify

--- a/include/progname.h
+++ b/include/progname.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* progname.h -- a library for setting the name of each plugin module
 
    This program is free software: you can redistribute it and/or modify

--- a/include/progversion.h
+++ b/include/progversion.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* progversion.h -- version number of the nagios-plugins-linux
 
    This program is free software: you can redistribute it and/or modify

--- a/include/string-macros.h
+++ b/include/string-macros.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* string-macros.h -- a collection of macros for checking strings
 
    This program is free software: you can redistribute it and/or modify

--- a/include/sysfsparser.h
+++ b/include/sysfsparser.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* sysfsparser -- get informations from sysfs
 
    This program is free software: you can redistribute it and/or modify

--- a/include/system.h
+++ b/include/system.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* system.h -- system and compiler specific stuff
 
    This program is free software: you can redistribute it and/or modify

--- a/include/tcpinfo.h
+++ b/include/tcpinfo.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* tcpinfo -- library for getting TCP network and socket informations
 
    This program is free software: you can redistribute it and/or modify

--- a/include/testutils.h
+++ b/include/testutils.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* testutils.h -- a simple framework for unit testing
 
    This program is free software: you can redistribute it and/or modify

--- a/include/thresholds.h
+++ b/include/thresholds.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* thresholds.h -- nagios thresholds
 
    This program is free software: you can redistribute it and/or modify

--- a/include/units.h
+++ b/include/units.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* units.h -- a library for converting between memory units
 
    This program is free software: you can redistribute it and/or modify

--- a/include/url_encode.h
+++ b/include/url_encode.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*  url_encode.h -- encode a string representing an URL
 
     This program is free software: you can redistribute it and/or modify

--- a/include/vminfo.h
+++ b/include/vminfo.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* vminfo.h -- library for getting virtual memory informations
 
    This program is free software: you can redistribute it and/or modify

--- a/include/xalloc.h
+++ b/include/xalloc.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* xalloc.h -- malloc with out-of-memory checking
 
    Copyright (C) 1990-2000, 2003-2004, 2006-2012 Free Software Foundation, Inc.

--- a/include/xasprintf.h
+++ b/include/xasprintf.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* xasprintf.h -- asprintf with out-of-memory checking.
 
    This program is free software: you can redistribute it and/or modify

--- a/include/xstrton.h
+++ b/include/xstrton.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* xstrton.h -- string to double and long conversion with error checking
 
    This program is free software: you can redistribute it and/or modify

--- a/lib/collection.c
+++ b/lib/collection.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2018 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/container_docker_count.c
+++ b/lib/container_docker_count.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2018 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/container_docker_memory.c
+++ b/lib/container_docker_memory.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2018 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/container_podman.c
+++ b/lib/container_podman.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2020 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/container_podman_count.c
+++ b/lib/container_podman_count.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2020 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/container_podman_stats.c
+++ b/lib/container_podman_stats.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2020 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/cpudesc.c
+++ b/lib/cpudesc.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014-2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/cpufreq.c
+++ b/lib/cpufreq.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/cpustats.c
+++ b/lib/cpustats.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/cputopology.c
+++ b/lib/cputopology.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014-2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/interrupts.c
+++ b/lib/interrupts.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/json_helpers.c
+++ b/lib/json_helpers.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2020 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/kernelver.c
+++ b/lib/kernelver.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/meminfo.c
+++ b/lib/meminfo.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014-2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/meminfo_procps.c
+++ b/lib/meminfo_procps.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/messages.c
+++ b/lib/messages.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  *

--- a/lib/mountlist.c
+++ b/lib/mountlist.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2013 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/netinfo.c
+++ b/lib/netinfo.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2020 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/perfdata.c
+++ b/lib/perfdata.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2019 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/processes.c
+++ b/lib/processes.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/procparser.c
+++ b/lib/procparser.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/progname.c
+++ b/lib/progname.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  *

--- a/lib/sysfsparser.c
+++ b/lib/sysfsparser.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2019 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/tcpinfo.c
+++ b/lib/tcpinfo.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/thresholds.c
+++ b/lib/thresholds.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPL
  * Copyright (c) 2006 Nagios Plugins Development Team

--- a/lib/url_encode.c
+++ b/lib/url_encode.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: Public Domain
  * Copyright (c) Fred Bulback

--- a/lib/vminfo.c
+++ b/lib/vminfo.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/vminfo_procps.c
+++ b/lib/vminfo_procps.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/lib/xasprintf.c
+++ b/lib/xasprintf.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* asprintf with out-of-memory checking.
 
    This program is free software: you can redistribute it and/or modify

--- a/lib/xmalloc.c
+++ b/lib/xmalloc.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* xmalloc.c -- malloc with out of memory checking
  *
  * Copyright (C) 1990-2000, 2002-2006, 2008-2012 Free Software Foundation, Inc.

--- a/lib/xstrton.c
+++ b/lib/xstrton.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /* strtol with error checking
 
    This program is free software: you can redistribute it and/or modify

--- a/plugins/check_clock.c
+++ b/plugins/check_clock.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_cpu.c
+++ b/plugins/check_cpu.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015,2020 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_cpufreq.c
+++ b/plugins/check_cpufreq.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015,2019 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_cswch.c
+++ b/plugins/check_cswch.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_docker.c
+++ b/plugins/check_docker.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2018 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_fc.c
+++ b/plugins/check_fc.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_ifmountfs.c
+++ b/plugins/check_ifmountfs.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2013 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_intr.c
+++ b/plugins/check_intr.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015,2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_memory.c
+++ b/plugins/check_memory.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014-2019 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_multipath.c
+++ b/plugins/check_multipath.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2013,2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_nbprocs.c
+++ b/plugins/check_nbprocs.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_network.c
+++ b/plugins/check_network.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015,2020 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_paging.c
+++ b/plugins/check_paging.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015,2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_podman.c
+++ b/plugins/check_podman.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2020 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_readonlyfs.c
+++ b/plugins/check_readonlyfs.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2013-2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_tcpcount.c
+++ b/plugins/check_tcpcount.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_temperature.c
+++ b/plugins/check_temperature.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_uptime.c
+++ b/plugins/check_uptime.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2010-2019 Davide Madrisan <davide.madrisan@gmail.com>

--- a/plugins/check_users.c
+++ b/plugins/check_users.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2014,2015 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/testutils.c
+++ b/tests/testutils.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2016,2018 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tsclock_thresholds.c
+++ b/tests/tsclock_thresholds.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2016 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tscswch.c
+++ b/tests/tscswch.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2016,2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tsintr.c
+++ b/tests/tsintr.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2016,2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslib_uname.c
+++ b/tests/tslib_uname.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2016 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslibcontainer_docker_count.c
+++ b/tests/tslibcontainer_docker_count.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2018 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslibcontainer_docker_memory.c
+++ b/tests/tslibcontainer_docker_memory.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2018 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslibkernelver.c
+++ b/tests/tslibkernelver.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2016 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslibmeminfo_conversions.c
+++ b/tests/tslibmeminfo_conversions.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslibmeminfo_interface.c
+++ b/tests/tslibmeminfo_interface.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslibmeminfo_procparser.c
+++ b/tests/tslibmeminfo_procparser.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslibmessages.c
+++ b/tests/tslibmessages.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2016 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslibperfdata.c
+++ b/tests/tslibperfdata.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2019 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tsliburlencode.c
+++ b/tests/tsliburlencode.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2018 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tslibvminfo.c
+++ b/tests/tslibvminfo.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tsload_normalize.c
+++ b/tests/tsload_normalize.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tsload_thresholds.c
+++ b/tests/tsload_thresholds.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tspaging.c
+++ b/tests/tspaging.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2016,2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tstemperature.c
+++ b/tests/tstemperature.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tststestutils.c
+++ b/tests/tststestutils.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>

--- a/tests/tsuptime.c
+++ b/tests/tsuptime.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
  * Copyright (c) 2017 Davide Madrisan <davide.madrisan@gmail.com>


### PR DESCRIPTION
Add to all the code files the corresponding SPDX License Identifiers.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>