### PR TITLE
lib/netinfo: display WireGuard interfaces

### DIFF
--- a/include/netinfo-private.h
+++ b/include/netinfo-private.h
@@ -25,9 +25,8 @@ extern "C"
 {
 #endif
 
-  typedef struct iflist
+  typedef struct ifstats
   {
-    char *ifname;
     unsigned int tx_packets;
     unsigned int rx_packets;
     unsigned int tx_bytes;
@@ -37,10 +36,17 @@ extern "C"
     unsigned int tx_dropped;
     unsigned int rx_dropped;
     unsigned int collisions;
-    unsigned int flags;
     unsigned int multicast;
-    uint32_t speed;        /* the link speed in Mbps */
-    uint8_t duplex;        /* the duplex as defined in <linux/ethtool.h> */
+  } ifstats_t;
+
+  typedef struct iflist
+  {
+    char *ifname;
+    uint8_t addr_family;
+    uint8_t duplex;	   /* the duplex as defined in <linux/ethtool.h> */
+    uint32_t speed;	   /* the link speed in Mbps */
+    unsigned int flags;
+    struct ifstats *stats;
     struct iflist *next;
   } iflist_t;
 

--- a/include/netinfo.h
+++ b/include/netinfo.h
@@ -30,6 +30,10 @@ extern "C"
 
   enum
   {
+    /* list of address families */
+    IF_AF_PACKET	= (1 << 0),
+    IF_AF_INET		= (1 << 1),
+    IF_AF_INET6		= (1 << 2),
     /* command-line options */
     CHECK_LINK		= (1 << 0),
     NO_LOOPBACK		= (1 << 1),
@@ -61,6 +65,7 @@ extern "C"
 
   /* Accessing the values from struct iflist */
   const char *iflist_get_ifname (struct iflist *ifentry);
+  uint8_t iflist_get_addr_family (struct iflist *ifentry);
   uint8_t iflist_get_duplex (struct iflist *ifentry);
   uint32_t iflist_get_speed (struct iflist *ifentry);
   unsigned int iflist_get_tx_packets (struct iflist *ifentry);

--- a/lib/netinfo.c
+++ b/lib/netinfo.c
@@ -27,6 +27,7 @@
 #include <linux/if.h>
 #include <linux/wireless.h>
 #include <math.h>
+#include <sys/socket.h>
 
 #include "common.h"
 #include "logging.h"

--- a/lib/netinfo.c
+++ b/lib/netinfo.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <linux/ethtool.h>
+#include <linux/if.h>
 #include <linux/wireless.h>
 #include <math.h>
 

--- a/lib/netinfo.c
+++ b/lib/netinfo.c
@@ -23,11 +23,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <math.h>
+#include <sys/socket.h>
 #include <linux/ethtool.h>
 #include <linux/if.h>
 #include <linux/wireless.h>
-#include <math.h>
-#include <sys/socket.h>
 
 #include "common.h"
 #include "logging.h"

--- a/lib/netinfo.c
+++ b/lib/netinfo.c
@@ -78,37 +78,60 @@ netinfo (unsigned int options, const char *ifname_regex, unsigned int seconds,
 	  bool if_up = if_flags_UP (ifl->flags),
 	       if_running = if_flags_RUNNING (ifl->flags);
 
+	  if (ifl->stats)
+	    {
 #define DIV(a, b) ceil (((b) - (a)) / (double)seconds)
-	  dbg ("\ttx_packets : %u %u\n", ifl->tx_packets, ifl2->tx_packets);
-	  ifl->tx_packets = DIV (ifl->tx_packets, ifl2->tx_packets);
+	      dbg ("\ttx_packets : %u %u\n",
+		   ifl->stats->tx_packets, ifl2->stats->tx_packets);
+	      ifl->stats->tx_packets = DIV (ifl->stats->tx_packets,
+					    ifl2->stats->tx_packets);
 
-	  dbg ("\trx_packets : %u %u\n", ifl->rx_packets, ifl2->rx_packets);
-	  ifl->rx_packets = DIV (ifl->rx_packets, ifl2->rx_packets);
+	      dbg ("\trx_packets : %u %u\n",
+		   ifl->stats->rx_packets, ifl2->stats->rx_packets);
+	      ifl->stats->rx_packets = DIV (ifl->stats->rx_packets,
+					    ifl2->stats->rx_packets);
 
-	  dbg ("\ttx_bytes   : %u %u\n", ifl->tx_bytes, ifl2->tx_bytes);
-	  ifl->tx_bytes   = DIV (ifl->tx_bytes, ifl2->tx_bytes);
+	      dbg ("\ttx_bytes   : %u %u\n",
+		   ifl->stats->tx_bytes, ifl2->stats->tx_bytes);
+	      ifl->stats->tx_bytes   = DIV (ifl->stats->tx_bytes,
+					    ifl2->stats->tx_bytes);
 
-	  dbg ("\trx_bytes   : %u %u\n", ifl->rx_bytes, ifl2->rx_bytes);
-	  ifl->rx_bytes   = DIV (ifl->rx_bytes, ifl2->rx_bytes);
+	      dbg ("\trx_bytes   : %u %u\n",
+		   ifl->stats->rx_bytes, ifl2->stats->rx_bytes);
+	      ifl->stats->rx_bytes   = DIV (ifl->stats->rx_bytes,
+					    ifl2->stats->rx_bytes);
 
-	  dbg ("\ttx_errors  : %u %u\n", ifl->tx_errors, ifl2->tx_errors);
-	  ifl->tx_errors  = DIV (ifl->tx_errors, ifl2->tx_errors);
+	      dbg ("\ttx_errors  : %u %u\n",
+		   ifl->stats->tx_errors, ifl2->stats->tx_errors);
+	      ifl->stats->tx_errors  = DIV (ifl->stats->tx_errors,
+					    ifl2->stats->tx_errors);
 
-	  dbg ("\trx_errors  : %u %u\n", ifl->rx_errors, ifl2->rx_errors);
-	  ifl->rx_errors  = DIV (ifl->rx_errors, ifl2->rx_errors);
+	      dbg ("\trx_errors  : %u %u\n",
+		   ifl->stats->rx_errors, ifl2->stats->rx_errors);
+	      ifl->stats->rx_errors  = DIV (ifl->stats->rx_errors,
+					    ifl2->stats->rx_errors);
 
-	  dbg ("\ttx_dropped : %u %u\n", ifl->tx_dropped, ifl2->tx_dropped);
-	  ifl->tx_dropped = DIV (ifl->tx_dropped, ifl2->tx_dropped);
+	      dbg ("\ttx_dropped : %u %u\n",
+		   ifl->stats->tx_dropped, ifl2->stats->tx_dropped);
+	      ifl->stats->tx_dropped = DIV (ifl->stats->tx_dropped,
+					    ifl2->stats->tx_dropped);
 
-	  dbg ("\trx_dropped : %u %u\n", ifl->rx_dropped, ifl2->rx_dropped);
-	  ifl->rx_dropped = DIV (ifl->rx_dropped, ifl2->rx_dropped);
+	      dbg ("\trx_dropped : %u %u\n",
+		   ifl->stats->rx_dropped, ifl2->stats->rx_dropped);
+	      ifl->stats->rx_dropped = DIV (ifl->stats->rx_dropped,
+					    ifl2->stats->rx_dropped);
 
-	  dbg ("\tcollisions : %u %u\n", ifl->collisions, ifl2->collisions);
-	  ifl->collisions = DIV (ifl->collisions, ifl2->collisions);
+	      dbg ("\tcollisions : %u %u\n",
+		   ifl->stats->collisions, ifl2->stats->collisions);
+	      ifl->stats->collisions = DIV (ifl->stats->collisions,
+					    ifl2->stats->collisions);
 
-	  dbg ("\tmulticast  : %u %u\n", ifl->multicast, ifl2->multicast);
-	  ifl->multicast  = DIV (ifl->multicast, ifl2->multicast);
+	      dbg ("\tmulticast  : %u %u\n",
+		   ifl->stats->multicast, ifl2->stats->multicast);
+	      ifl->stats->multicast  = DIV (ifl->stats->multicast,
+					    ifl2->stats->multicast);
 #undef DIV
+	    }
 
 	  dbg ("\tlink UP: %s\n", if_up ? "true" : "false");
 	  dbg ("\tlink RUNNING: %s\n", if_running ? "true" : "false");
@@ -147,6 +170,12 @@ iflist_get_ifname (struct iflist *ifentry)
 }
 
 uint8_t
+iflist_get_addr_family (struct iflist *ifentry)
+{
+  return ifentry->addr_family;
+}
+
+uint8_t
 iflist_get_duplex (struct iflist *ifentry)
 {
   return ifentry->duplex;
@@ -158,12 +187,20 @@ iflist_get_speed (struct iflist *ifentry)
   return ifentry->speed;
 }
 
+unsigned int
+iflist_get_flags (struct iflist *ifentry)
+{
+  return ifentry->flags;
+}
+
+/* FIXME: should perhaps not return 0 if the interface stats are not available
+ *        but this seems to be the behaviour of the commands "ifconfig" and
+ *        "ip -s link"  */
 #define __iflist_get__(arg) \
 unsigned int iflist_get_ ## arg (struct iflist *ifentry) \
-  { return ifentry->arg; }
+  { return ifentry->stats ? ifentry->stats->arg : 0; }
 
 __iflist_get__(collisions)
-__iflist_get__(flags)
 __iflist_get__(multicast)
 __iflist_get__(tx_packets)
 __iflist_get__(rx_packets)
@@ -219,18 +256,21 @@ void print_ifname_debug (struct iflist *iflhead, unsigned int options)
 	      , ifspeed ? ifspeed : ""
 	      , ifduplex ? ifduplex : "");
 
-      if (pd_bytes)
-	__printf_tx_rx__ ("byte/s", tx_only, rx_only);
-      if (pd_errors)
-	__printf_tx_rx__ ("err/s", tx_only, rx_only);
-      if (pd_drops)
-	__printf_tx_rx__ ("drop/s", tx_only, rx_only);
-      if (pd_packets)
-	__printf_tx_rx__ ("pck/s", tx_only, rx_only);
-      if (pd_collisions)
-	fprintf (stdout, " - %s_coll/s\n", ifl->ifname);
-      if (pd_multicast)
-	fprintf (stdout, " - %s_mcast/s\n", ifl->ifname);
+      if (ifl->stats)
+	{
+	  if (pd_bytes)
+	    __printf_tx_rx__ ("byte/s", tx_only, rx_only);
+	  if (pd_errors)
+	    __printf_tx_rx__ ("err/s", tx_only, rx_only);
+	  if (pd_drops)
+	    __printf_tx_rx__ ("drop/s", tx_only, rx_only);
+	  if (pd_packets)
+	    __printf_tx_rx__ ("pck/s", tx_only, rx_only);
+	  if (pd_collisions)
+	    fprintf (stdout, " - %s_coll/s\n", ifl->ifname);
+	  if (pd_multicast)
+	    fprintf (stdout, " - %s_mcast/s\n", ifl->ifname);
+	}
     }
 #undef __printf_tx_rx__
 }


### PR DESCRIPTION
The WireGuard interfaces are of type AF_INET and were
previously skipped (only the AF_PACKET ones were reported).

Add all the AF_INET/AF_INET6 ones that have no AF_PACKET
correspondent..

This should (partially) solve the issue opened by <https://github.com/sbraz>

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>