### PR TITLE
lib/netinfo*: switch from getifaddrs glib call to linux rtnetlink

### DIFF
--- a/include/netinfo-private.h
+++ b/include/netinfo-private.h
@@ -42,7 +42,6 @@ extern "C"
   typedef struct iflist
   {
     char *ifname;
-    uint8_t addr_family;
     uint8_t duplex;	   /* the duplex as defined in <linux/ethtool.h> */
     uint32_t speed;	   /* the link speed in Mbps */
     unsigned int flags;

--- a/include/netinfo.h
+++ b/include/netinfo.h
@@ -65,7 +65,6 @@ extern "C"
 
   /* Accessing the values from struct iflist */
   const char *iflist_get_ifname (struct iflist *ifentry);
-  uint8_t iflist_get_addr_family (struct iflist *ifentry);
   uint8_t iflist_get_duplex (struct iflist *ifentry);
   uint32_t iflist_get_speed (struct iflist *ifentry);
   unsigned int iflist_get_tx_packets (struct iflist *ifentry);

--- a/lib/netinfo.c
+++ b/lib/netinfo.c
@@ -172,12 +172,6 @@ iflist_get_ifname (struct iflist *ifentry)
 }
 
 uint8_t
-iflist_get_addr_family (struct iflist *ifentry)
-{
-  return ifentry->addr_family;
-}
-
-uint8_t
 iflist_get_duplex (struct iflist *ifentry)
 {
   return ifentry->duplex;

--- a/plugins/check_network.c
+++ b/plugins/check_network.c
@@ -467,7 +467,7 @@ main (int argc, char **argv)
     status = STATE_UNKNOWN;
 
   int i = 0;
-  printf ("%s %s - found %u interface(s) ("
+  printf ("%s %s - found %u interface(s): "
 	  , plugin_progname
 	  , state_text (status)
 	  , ninterfaces);
@@ -479,7 +479,7 @@ main (int argc, char **argv)
 	printf (",...");
 	break;
       }
-  printf (") | %s\n", bp);
+  printf (" | %s\n", bp);
 
   freeiflist (iflhead);
   free (my_threshold);


### PR DESCRIPTION
Switch to linux rtnetlink to be able to get the required
informations for all the network interfaces available.
    
This new implementation in particular works also for the
WireGuard interfaces.