### PR TITLE
packages: make it possible to build packages for Fedora 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,20 +124,21 @@ CentOS 8           | `make -C packages centos-8`
 Debian 8 (Jessie)  | `make -C packages debian-jessie`
 Debian 9 (Stretch) | `make -C packages debian-stretch`
 Debian 10 (Buster) | `make -C packages debian-buster`
-Fedora 30          | `make -C packages fedora-30`
 Fedora 31          | `make -C packages fedora-31`
 Fedora 32          | `make -C packages fedora-32`
+Fedora 33          | `make -C packages fedora-33`
 Fedora Rawhide     | `make -C packages fedora-rawhide`
 
 in the root source folder.
 The building process requires the _Docker_ software containerization platform running on your system, and an internet connection to download the Docker images of the operating systems you want to build the packages for.
 
-On *Fedora 31* and *Fedora 32* you can use the native *Podman* pod manager along with the Docker CLI emulation script:
+On *Fedora* you can use the native *Podman* pod manager along with the Docker CLI emulation script:
 
     sudo install dnf podman podman-docker
 
 _Note_: the previous make commands can end with a `permission denied` error if *selinux* is configured in enforcing mode.
-In this case you can temporarily disable *selinux* by executing as root the command `setenforce 0`.
+In this case you can temporarily disable *selinux* by executing as root the command `setenforce 0`
+(or maybe share a better solution!).
 
 ## Gentoo Package
 

--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -34,11 +34,11 @@ MULTIBUILD_OPTS = \
 
 TARGETS_REDHAT = \
 	centos-5 centos-6 centos-7 centos-8 \
-	fedora-30 fedora-31 fedora-32 \
+	fedora-31 fedora-32 fedora-33 \
 	fedora-rawhide
 
 centos-latest: centos-8
-fedora-latest: fedora-32
+fedora-latest: fedora-33
 
 TARGETS_DEBIAN = \
 	debian-jessie debian-stretch debian-buster

--- a/packages/multibuild.sh
+++ b/packages/multibuild.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Multi-platform build system
-# Copyright (C) 2016-2019 Davide Madrisan <davide.madrisan@gmail.com>
+# Copyright (C) 2016-2020 Davide Madrisan <davide.madrisan@gmail.com>
 
 PROGNAME="${0##*/}"
 PROGPATH="${0%/*}"
@@ -33,9 +33,9 @@ Where:
    -u|--uid    : user ID of the user 'developer' used for building the software
 
 Supported distributions:
-   CentOS 5/6/7
+   CentOS 5/6/7/8
    Debian jessie/stretch/buster
-   Fedora 28/29/30/rawhide
+   Fedora 31/32/33/rawhide
 
 Example:
        $0 -s $PROGPATH/../../nagios-plugins-linux:/shared:rw \\
@@ -50,7 +50,7 @@ __EOF
 help () {
    cat <<__EOF
 $PROGNAME v$REVISION - containerized software build checker
-Copyright (C) 2016-2019 Davide Madrisan <davide.madrisan@gmail.com>
+Copyright (C) 2016-2020 Davide Madrisan <davide.madrisan@gmail.com>
 
 __EOF
 


### PR DESCRIPTION
Make it possible to build rpm packages for Fedora 33
by using the command "make -C packages fedora-33".

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>