### PR TITLE
packages: add Alpine package creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The `.rpm` and `.deb` packages for CentOS/RHEL, Debian, and Fedora can be built 
 
 Command            | Distribution
 ------------------ | ------------
+Alpine 3.12        | `make -C packages alpine-3.12`
 CentOS 5           | `make -C packages centos-5`
 CentOS 6           | `make -C packages centos-6`
 CentOS 7           | `make -C packages centos-7`

--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -32,21 +32,23 @@ MULTIBUILD_OPTS = \
 	--uid $(UID) \
 	--pckver $(PACKAGE_VERSION)
 
-TARGETS_REDHAT = \
-	centos-5 centos-6 centos-7 centos-8 \
-	fedora-31 fedora-32 fedora-33 \
-	fedora-rawhide
-
-centos-latest: centos-8
-fedora-latest: fedora-33
+TARGETS_ALPINE = \
+	alpine-3.12
+alpine-latest: alpine-3.12
 
 TARGETS_DEBIAN = \
 	debian-jessie debian-stretch debian-buster
-
 debian-8: debian-jessie
 debian-9: debian-stretch
 debian-10: debian-buster
 debian-latest: debian-buster
+
+TARGETS_REDHAT = \
+	centos-5 centos-6 centos-7 centos-8 \
+	fedora-31 fedora-32 fedora-33 \
+	fedora-rawhide
+centos-latest: centos-8
+fedora-latest: fedora-33
 
 .PHONY: specfile
 specfile:
@@ -56,15 +58,21 @@ specfile:
 source-archive:
 	@cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) dist
 
-$(TARGETS_REDHAT): specfile source-archive $(DOCKER) $(MULTIBUILD_SCRIPT)
+$(TARGETS_ALPINE): source-archive $(DOCKER) $(MULTIBUILD_SCRIPT)
 	@distr=`echo $@ | sed s/-/:/`; \
 	$(SHELL) $(MULTIBUILD_SCRIPT) $(MULTIBUILD_OPTS) \
-	   --spec $(multibuilddir)/specs/$(SPECFILE) \
+	   --spec $(multibuilddir)/specs/APKBUILD \
 	   --os $$distr --target pcks/$@
 
 $(TARGETS_DEBIAN): source-archive $(DOCKER) $(MULTIBUILD_SCRIPT)
 	@distr=`echo $@ | sed s/-/:/`-slim; \
 	$(SHELL) $(MULTIBUILD_SCRIPT) $(MULTIBUILD_OPTS) \
+	   --os $$distr --target pcks/$@
+
+$(TARGETS_REDHAT): specfile source-archive $(DOCKER) $(MULTIBUILD_SCRIPT)
+	@distr=`echo $@ | sed s/-/:/`; \
+	$(SHELL) $(MULTIBUILD_SCRIPT) $(MULTIBUILD_OPTS) \
+	   --spec $(multibuilddir)/specs/$(SPECFILE) \
 	   --os $$distr --target pcks/$@
 
 EXTRA_DIST = docker-shell-helpers multibuild.sh

--- a/packages/docker-shell-helpers/docker-shell-helpers.sh
+++ b/packages/docker-shell-helpers/docker-shell-helpers.sh
@@ -63,7 +63,7 @@ container_exec_command() {
    # doc.desc: run a command (or a sequence of commands) inside a container
    # doc.args: container name
    __validate_input "${FUNCNAME[0]}" "$1"
-   sudo docker exec -it "$1" /bin/bash -c "$2"
+   sudo docker exec -it "$1" /bin/sh -c "$2"
 }
 
 container_property() {
@@ -113,7 +113,9 @@ container_exec_command "$container_name" "\
       cat /etc/debian_version
    fi")"
           set -- $container_os
-          if [ "$1" = "CentOS" ]; then
+	  if [ "$1" = "alpine" ]; then
+             os="alpine-${2}"
+          elif [ "$1" = "CentOS" ]; then
              [ "$2" = "Linux" ] && os="centos-${4}" || os="centos-${3}"
           elif [ "$1" = "Fedora" ]; then
              os="fedora-${3}"
@@ -157,7 +159,7 @@ container_create() {
 
    if ! (container_exists "$name" ||
       sudo docker run -itd --name="$name" ${disk:+-v $disk} "$os" \
-         "/bin/bash" >/dev/null); then
+         "/bin/sh" >/dev/null); then
       __die "${FUNCNAME[0]}: cannot instantiate the container $name"
    fi
    echo "$name"

--- a/packages/specs/APKBUILD.in
+++ b/packages/specs/APKBUILD.in
@@ -1,0 +1,44 @@
+# Contributor:
+# Maintainer: Davide Madrisan <davide.madrisan@gmail.com>
+pkgname=@package@
+pkgver=@version@
+pkgrel=@release@
+pkgdesc="Nagios Plugins for Linux"
+url="https://github.com/madrisan/nagios-plugins-linux"
+arch="all"
+license="GPL-3.0-or-later"
+depends=""
+makedepends="autoconf automake bzip2 curl-dev file gcc libtool linux-headers make m4 musl-dev tar xz"
+install=""
+subpackages=""
+source="$pkgname-$pkgver.tar.xz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+prepare() {
+        cd "$builddir"
+        autoreconf -vif || return 1
+}
+
+build() {
+        cd "$builddir"
+        ./configure \
+                --build=$CBUILD \
+                --host=$CHOST \
+                --prefix=/usr \
+		--libexecdir=/usr/lib/nagios/plugins \
+                --sysconfdir=/etc \
+                --mandir=/usr/share/man \
+                --localstatedir=/var
+        make
+}
+
+check() {
+        cd "$builddir"
+        make check
+}
+
+package() {
+        make DESTDIR="$pkgdir" install
+}
+
+sha512sums="129c696cee4b2638e6106289e398f6823caabb382ca8e1a867f8b35985f99d7dc69a14308eaeed0a6b788e244a13778c7cdf28b4ff70354b5620f7d646225a44 nagios-plugins-linux-27.tar.xz"

--- a/packages/specs/Makefile.am
+++ b/packages/specs/Makefile.am
@@ -15,7 +15,7 @@
 ## You should have received a copy of the GNU General Public License
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-INFILES := $(wildcard *.spec.in)
+INFILES := $(wildcard APKBUILD.in *.spec.in)
 OUTFILES := $(INFILES:.in=)
 
 PACKAGE_RELEASE = 1


### PR DESCRIPTION
Make it possible to create basic Linux Alpine .apk packages
by running the command: make -C packages alpine-3.12

As usual this make command requires docker or podman to work.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>