### PR TITLE
build: check_network fails to link on ARM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,18 @@ AC_CHECK_FUNCS([ \
   secure_getenv\
 ])
 
+dnl Check for ceil (some platforms use libm for the math functions
+dnl instead of the C library
+dnl wanted by lib/netinfo.c
+
+LIBS_SAVE="$LIBS"
+AC_SEARCH_LIBS([ceil], [m], [], [
+  AC_MSG_ERROR([unable to find the ceil() function])
+])
+CEIL_LIBS="$LIBS"
+AC_SUBST([CEIL_LIBS])
+LIBS="$LIBS_SAVE"
+
 dnl Check for clock_gettime CLOCK_MONOTONIC
 dnl wanted by: plugins/check_uptime.c
 LIBS_SAVE="$LIBS"

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -122,7 +122,7 @@ if HAVE_PROC_MEMINFO
 check_memory_LDADD       = $(LDADD) $(LIBPROCPS_LIBS)
 endif
 check_nbprocs_LDADD      = $(LDADD)
-check_network_LDADD      = $(LDADD)
+check_network_LDADD      = $(LDADD) $(CEIL_LIBS)
 check_multipath_LDADD    = $(LDADD)
 check_paging_LDADD       = $(LDADD) $(LIBPROCPS_LIBS)
 if HAVE_LIBVARLINK


### PR DESCRIPTION
Fix the regression introduced by commit 07c1239:

    libtool: link: gcc -std=gnu99 -Wall -Wformat -Wformat -Wformat-security -Wformat-signedness -Wimplicit-fallthrough=2 -Wmissing-noreturn -Wmissing-format-attribute -Wredundant-decls -Wshadow -Wsign-compare -Wstrict-aliasing=2 -Wstringop-truncation -Wunused -Wstack-protector -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -fPIE -g -O2 -fdebug-prefix-map=/home/stb-tester/workspace/build/nagios-plugins-linux/nagios-plugins-linux-28=. -fstack-protector-strong -Wformat -Werror=format-security -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,relro -o check_network check_network.o  ../lib/libutils.a
    /usr/bin/ld: ../lib/libutils.a(netinfo.o): in function `netinfo':
    ./lib/netinfo.c:88: undefined reference to `ceil'
    /usr/bin/ld: ./lib/netinfo.c:93: undefined reference to `ceil'
    /usr/bin/ld: ./lib/netinfo.c:98: undefined reference to `ceil'
    /usr/bin/ld: ./lib/netinfo.c:103: undefined reference to `ceil'
    /usr/bin/ld: ./lib/netinfo.c:108: undefined reference to `ceil'
    /usr/bin/ld: ../lib/libutils.a(netinfo.o):./lib/netinfo.c:113: more undefined references to `ceil' follow
    collect2: error: ld returned 1 exit status
    make[3]: *** [Makefile:641: check_network] Error 1
    make[3]: *** Waiting for unfinished jobs...

Thanks to vincent-olivert-riera for reporting this issue when compiling
nagios-plugins-linux on ARM.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>