### PR TITLE
check_temperature: improve the output message

### DIFF
--- a/include/string-macros.h
+++ b/include/string-macros.h
@@ -26,6 +26,8 @@
 # define STRNEQLEN(a, b, n) (strncmp(a, b, n) != 0)
 # define STRPREFIX(a, b) (strncmp(a, b, strlen(b)) == 0)
 
+# define STRTRIMPREFIX(a, b) STRPREFIX(a, b) ? a + strlen(b) : a
+
 /* Use strncpy with N-1 and ensure the string is terminated.  */
 #define STRNCPY_TERMINATED(DEST, SRC, N) \
   do { \

--- a/include/sysfsparser.h
+++ b/include/sysfsparser.h
@@ -65,9 +65,11 @@ extern "C"
 # define ALL_THERMAL_ZONES   UINT_MAX
 
   bool sysfsparser_thermal_kernel_support (void);
+  const char *sysfsparser_thermal_sysfs_path ();
   int sysfsparser_thermal_get_temperature (unsigned int selected_zone,
 					   unsigned int *zone, char **type);
   int sysfsparser_thermal_get_critical_temperature (unsigned int thermal_zone);
+  const char *sysfsparser_thermal_get_device (unsigned int thermal_zone);
 
 #ifdef __cplusplus
 }

--- a/lib/sysfsparser.c
+++ b/lib/sysfsparser.c
@@ -342,6 +342,12 @@ sysfsparser_thermal_kernel_support ()
   return true;
 }
 
+const char *
+sysfsparser_thermal_sysfs_path ()
+{
+  return PATH_SYS_ACPI_THERMAL;
+}
+
 int
 sysfsparser_thermal_get_critical_temperature (unsigned int thermal_zone)
 {
@@ -379,6 +385,19 @@ sysfsparser_thermal_get_critical_temperature (unsigned int thermal_zone)
     }
 
   return crit_temp;
+}
+
+const char *
+sysfsparser_thermal_get_device (unsigned int thermal_zone)
+{
+  char *device;
+  device = sysfsparser_getline (PATH_SYS_ACPI_THERMAL
+				"/thermal_zone%u/device/path",
+				thermal_zone);
+  if (NULL == device)
+    return "Virtual device";
+
+  return STRTRIMPREFIX (device, "\\_TZ_.");
 }
 
 int


### PR DESCRIPTION
Add the device information for the thermal zone when available.
If not says it's a "Virtual device" (hope it's correct).

Example of the new output:

    temperature OK - 39.0°C (thermal zone: 2 [EXTZ], type: "acpitz") | temp=39C;0;128
    temperature OK - 39.0°C (thermal zone: 3 [LOCZ], type: "acpitz") | temp=39C;0;128
    temperature OK - 31.0°C (thermal zone: 4 [BATZ], type: "acpitz") | temp=31C;0;128
    temperature OK - 39.5°C (thermal zone: 6 [Virtual device], type: "pch_skylake") | temp=39C;0;115
    temperature OK - 41.0°C (thermal zone: 7 [Virtual device], type: "iwlwifi_1") | temp=41C
    temperature OK - 44.0°C (thermal zone: 8 [Virtual device], type: "x86_pkg_temp") | temp=44C

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>