### PR TITLE
lib/netinfo: fix a LGTM alert

### DIFF
--- a/lib/netinfo-private.c
+++ b/lib/netinfo-private.c
@@ -346,7 +346,7 @@ get_netinfo_snapshot (unsigned int options, const regex_t *if_regex)
   while (!msg_done)
     {
       /* parse reply */
-      unsigned int len;
+      ssize_t len;
       struct nlmsghdr *h;
       struct msghdr rtnl_reply;
       struct iovec io_reply;


### PR DESCRIPTION
Fix the alert:

    Comparison is always false because ... = ... >= 0.

detected by the LGTM static code analyzer.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>