### PR TITLE
check_podman: Podman 3.x API support

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -66,3 +66,18 @@ cd nagios-plugins-linux
     LIBPROCPS_LIBS="-L/tmp/procps-ng-newlib/usr/lib64/ -lproc-2"
 make
 ```
+
+## Podman Plugin
+
+Connect to systemd user service manager and start/enable podman socket:
+```
+systemctl --user start podman.socket
+systemctl --user enable podman.socket
+```
+Check for API output:
+```
+curl --unix-socket /run/user/1000/podman/podman.sock http://d/v3.0.0/libpod/info | jq
+curl --unix-socket /run/user/1000/podman/podman.sock -v 'http://d/v3.0.0/libpod/images/json' | jq
+```
+
+Podman API Reference: https://docs.podman.io/en/latest/Reference.html

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here is the list of the available plugins:
 * **check_cpu** - checks the CPU (user mode) utilization
 * **check_cpufreq** - displays the CPU frequency characteristics
 * **check_cswch** - checks the total number of context switches across all CPUs
-* **check_docker** - checks the number of running docker containers (:warning: *alpha*, requires *libcurl* version 7.40.0+)
+* **check_docker** - checks the number of running docker containers (:warning: *pre-alpha*, requires *libcurl* version 7.40.0+)
 * **check_fc** - monitors the status of the fiber status ports
 * **check_ifmountfs** - checks whether the given filesystems are mounted
 * **check_intr** - monitors the total number of system interrupts
@@ -43,7 +43,7 @@ Here is the list of the available plugins:
   * check_network_multicast
 * **check_paging** - checks the memory and swap paging
 * **check_pressure** - checks Linux Pressure Stall Information (PSI) data :new:
-* **check_podman** - monitor the status of podman containers (:warning: *beta*, requires *libvarlink*)
+* **check_podman** - monitor the status of podman containers (:warning: *pre-alpha*, requires *libvarlink*)
 * **check_readonlyfs** - checks for readonly filesystems
 * **check_swap** - checks the swap usage
 * **check_tcpcount** - checks the tcp network usage

--- a/configure.ac
+++ b/configure.ac
@@ -347,18 +347,6 @@ AS_IF([test "x$enable_libcurl" != "xno"], [
   AM_CONDITIONAL(HAVE_LIBCURL, [test "$libcurl_cv_lib_curl_usable" = "yes"])
 ], [AM_CONDITIONAL(HAVE_LIBCURL, false)])
 
-dnl Check for libvarlink
-AC_ARG_ENABLE([libvarlink],
-  AS_HELP_STRING([--disable-libvarlink], [Disable libvarlink]))
-AS_IF([test "x$enable_libvarlink" != "xno"], [
-  PKG_CHECK_EXISTS([libvarlink],
-    [PKG_CHECK_MODULES(LIBVARLINK, [libvarlink >= 18],
-      [AC_DEFINE(HAVE_LIBVARLINK, 1, [Define if libvarlink is available])
-       have_libvarlink=yes],
-      AC_MSG_ERROR([*** libvarlink version 18 or better not found]))])
-])
-AM_CONDITIONAL(HAVE_LIBVARLINK, [test "$have_libvarlink" = "yes"])
-
 dnl Check for the procps newlib
 have_libprocps=no
 AC_ARG_ENABLE([libprocps],
@@ -416,16 +404,16 @@ AC_ARG_WITH(
   [DOCKER_SOCKET="$with_dockersocket"])
 AC_SUBST(DOCKER_SOCKET)
 
-dnl Add the option: '--with-varlink-address'
-VARLINK_ADDRESS="unix:/run/podman/io.podman"
+dnl Add the option: '--with-podman-socket'
+PODMAN_SOCKET="/run/podman/podman.sock"
 AC_ARG_WITH(
-  [varlinkaddress],
+  [podmansocket],
   [AS_HELP_STRING(
-    [--with-varlink-address],
-    [use a different address for varlink socket
-     (default is unix:/run/podman/io.podman)])],
-  [VARLINK_ADDRESS="$with_varlinkaddress"])
-AC_SUBST(VARLINK_ADDRESS)
+    [--with-podman-socket],
+    [use a different path for podman socket
+     (default is /run/podman/podman.sock)])],
+  [PODMAN_SOCKET="$with_podmansocket"])
+AC_SUBST(PODMAN_SOCKET)
 
 dnl Add the option: '--with-socketfile'
 MULTIPATHD_SOCKET="@/org/kernel/linux/storage/multipathd"
@@ -578,7 +566,9 @@ if test "$libcurl_cv_lib_curl_usable" = "yes"; then
   echo
 fi
 
-if test "$have_libvarlink" = "yes"; then
-  echo "  VARLINK_ADDRESS    = $VARLINK_ADDRESS"
-  echo
+if test "$DOCKER_SOCKETx" != "x"; then
+  echo "  DOCKER_SOCKET      = $DOCKER_SOCKET"
+fi
+if test "$PODMAN_SOCKETx" != "x"; then
+  echo "  PODMAN_SOCKET      = $PODMAN_SOCKET"
 fi

--- a/include/container_podman.h
+++ b/include/container_podman.h
@@ -17,8 +17,6 @@
 #ifndef _CONTAINER_PODMAN_H
 #define _CONTAINER_PODMAN_H
 
-#include <varlink.h>
-
 #include "units.h"
 
 #ifdef __cplusplus
@@ -63,38 +61,6 @@ extern "C"
     pids_stats,
     last_stats = pids_stats
   } stats_type;
-
-#ifndef NPL_TESTING
-
-  typedef struct podman_varlink
-  {
-    int epoll_fd;
-    int signal_fd;
-    VarlinkConnection *connection;
-    VarlinkObject *parameters;
-  } podman_varlink_t;
-
-  long podman_varlink_callback (VarlinkConnection * connection,
-				const char *error, VarlinkObject * parameters,
-				uint64_t flags, void *userdata);
-  long podman_varlink_check_event (podman_varlink_t * pv);
-  long podman_varlink_list (podman_varlink_t *pv, VarlinkArray **list,
-			    char **err);
-  long podman_varlink_stats (podman_varlink_t *pv, const char *shortid,
-			     container_stats_t *stats, char **err);
-#else
-
-  struct podman_varlink;
-
-#endif
-
-  /* Allocates space for a new varlink object.
-   * Returns 0 if all went ok. Errors are returned as negative values.  */
-  int podman_varlink_new (podman_varlink_t **pv, char *varlinkaddr);
-
-  /* Drop a reference of the varlink library context. If the refcount of
-   * reaches zero, the resources of the context will be released.  */
-  podman_varlink_t *podman_varlink_unref (podman_varlink_t *pv);
 
   int podman_running_containers (podman_varlink_t *pv, unsigned int *count,
 				 const char *image, char **perfdata);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 	-include $(top_builddir)/config.h \
 	-I$(top_srcdir)/include \
 	-DDOCKER_SOCKET=\"$(DOCKER_SOCKET)\" \
-	-DVARLINK_ADDRESS=\"$(VARLINK_ADDRESS)\" \
+	-DPODMAN_SOCKET=\"$(PODMAN_SOCKET)\" \
 	$(LIBCURL_CPPFLAGS) \
 	$(LIBPROCPS_CPPFLAGS)
 
@@ -55,10 +55,6 @@ libutils_a_SOURCES =  \
 if HAVE_LIBCURL
   libutils_a_SOURCES += \
 	container_docker_count.c
-endif
-
-if HAVE_LIBVARLINK
-  libutils_a_SOURCES += \
 	container_podman.c \
 	container_podman_count.c \
 	container_podman_stats.c

--- a/lib/container_podman.c
+++ b/lib/container_podman.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * License: GPLv3+
- * Copyright (c) 2020 Davide Madrisan <davide.madrisan@gmail.com>
+ * Copyright (c) 2020,2021 Davide Madrisan <davide.madrisan@gmail.com>
  *
  * A library for checking for Podman metrics via varlink calls.
  *

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-## Copyright (c) 2014-2016 Davide Madrisan <davide.madrisan@gmail.com>
+## Copyright (c) 2014-2016,2021 Davide Madrisan <davide.madrisan@gmail.com>
 ##
 ## This program is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 	-include $(top_builddir)/config.h \
 	-I$(top_srcdir)/include \
 	-DMULTIPATHD_SOCKET=\"$(MULTIPATHD_SOCKET)\" \
-        -DVARLINK_ADDRESS=\"$(VARLINK_ADDRESS)\"
+        -DPODMAN_SOCKET=\"$(PODMAN_SOCKET)\"
 
 AM_CFLAGS = $(LIBPROCPS_CFLAGS)
 AM_LDFLAGS = $(LIBPROCPS_LIBS)
@@ -58,16 +58,13 @@ libexec_PROGRAMS += \
 endif
 if HAVE_LIBCURL
 libexec_PROGRAMS += \
-	check_docker
+	check_docker \
+	check_podman
 endif
 if HAVE_PROC_MEMINFO
 libexec_PROGRAMS += \
 	check_memory      \
 	check_swap
-endif
-if HAVE_LIBVARLINK
-libexec_PROGRAMS += \
-	check_podman
 endif
 
 check_clock_SOURCES      = check_clock.c
@@ -82,6 +79,7 @@ check_load_SOURCES       = check_load.c
 endif
 if HAVE_LIBCURL
 check_docker_SOURCES     = check_docker.c
+check_podman_SOURCES     = check_podman.c
 endif
 if HAVE_PROC_MEMINFO
 check_memory_SOURCES     = check_memory.c
@@ -90,9 +88,6 @@ check_multipath_SOURCES  = check_multipath.c
 check_nbprocs_SOURCES    = check_nbprocs.c
 check_network_SOURCES    = check_network.c
 check_paging_SOURCES     = check_paging.c
-if HAVE_LIBVARLINK
-check_podman_SOURCES     = check_podman.c
-endif
 check_pressure_SOURCES   = check_pressure.c
 check_readonlyfs_SOURCES = check_readonlyfs.c
 if HAVE_PROC_MEMINFO
@@ -117,6 +112,7 @@ check_load_LDADD         = $(LDADD)
 endif
 if HAVE_LIBCURL
 check_docker_LDADD       = $(LDADD) $(LIBCURL) -lm
+check_podman_LDADD       = $(LDADD) $(LIBVARLINK_LIBS)
 endif
 if HAVE_PROC_MEMINFO
 check_memory_LDADD       = $(LDADD) $(LIBPROCPS_LIBS)
@@ -125,9 +121,6 @@ check_nbprocs_LDADD      = $(LDADD)
 check_network_LDADD      = $(LDADD) $(CEIL_LIBS)
 check_multipath_LDADD    = $(LDADD)
 check_paging_LDADD       = $(LDADD) $(LIBPROCPS_LIBS)
-if HAVE_LIBVARLINK
-check_podman_LDADD       = $(LDADD) $(LIBVARLINK_LIBS)
-endif
 check_readonlyfs_LDADD   = $(LDADD)
 if HAVE_PROC_MEMINFO
 check_swap_LDADD         = $(LDADD)


### PR DESCRIPTION
Add support to Podman 3.x API now that libvarlink has been dropped.