### PR TITLE
Pressure fixes

### DIFF
--- a/lib/pressure.c
+++ b/lib/pressure.c
@@ -138,7 +138,8 @@ proc_psi_read (struct proc_psi_twolines **psi_io,
 {
   struct proc_psi_oneline psi;
   struct proc_psi_twolines *stats = *psi_io;
-  unsigned long long total;
+  unsigned long long some_total;
+  unsigned long long full_total;
 
   if (NULL == stats)
     {
@@ -150,25 +151,25 @@ proc_psi_read (struct proc_psi_twolines **psi_io,
   stats->some_avg10 = psi.avg10;
   stats->some_avg60 = psi.avg60;
   stats->some_avg300 = psi.avg300;
-  stats->some_total = total = psi.total;
+  stats->some_total = some_total = psi.total;
 
   proc_psi_parser (&psi, procfile, "full");
   stats->full_avg10 = psi.avg10;
   stats->full_avg60 = psi.avg60;
   stats->full_avg300 = psi.avg300;
-  stats->full_total = total = psi.total;
+  stats->full_total = full_total = psi.total;
 
   sleep (delay);
 
   proc_psi_parser (&psi, procfile, "some");
-  *starvation = (psi.total - total) / delay;
+  *starvation = (psi.total - some_total) / delay;
   dbg ("delta (over %lusec) for some: %llu ((%llu - %llu) / %lu)\n",
-       delay, *starvation, psi.total, total, delay);
+       delay, *starvation, psi.total, some_total, delay);
 
   proc_psi_parser (&psi, procfile, "full");
-  *(starvation + 1) = (psi.total - total) / delay;
+  *(starvation + 1) = (psi.total - full_total) / delay;
   dbg ("delta (over %lusec) for full: %llu ((%llu - %llu) / %lu)\n",
-       delay, *(starvation + 1), psi.total, total, delay);
+       delay, *(starvation + 1), psi.total, full_total, delay);
 
   return 0;
 }

--- a/lib/pressure.c
+++ b/lib/pressure.c
@@ -124,9 +124,9 @@ proc_psi_read_cpu (struct proc_psi_oneline **psi_cpu,
   sleep (delay);
 
   proc_psi_parser (&psi, procpath, "some");
-  *starvation = psi.total - total;
-  dbg ("delta (over %lusec): %llu (%llu - %llu)\n",
-       delay, *starvation, psi.total, total);
+  *starvation = (psi.total - total) / delay;
+  dbg ("delta (over %lusec): %llu ((%llu - %llu) / %lu)\n",
+       delay, *starvation, psi.total, total, delay);
 
   return 0;
 }
@@ -161,14 +161,14 @@ proc_psi_read (struct proc_psi_twolines **psi_io,
   sleep (delay);
 
   proc_psi_parser (&psi, procfile, "some");
-  *starvation = psi.total - total;
-  dbg ("delta (over %lusec) form some: %llu (%llu - %llu)\n",
-       delay, *starvation, psi.total, total);
+  *starvation = (psi.total - total) / delay;
+  dbg ("delta (over %lusec) for some: %llu ((%llu - %llu) / %lu)\n",
+       delay, *starvation, psi.total, total, delay);
 
   proc_psi_parser (&psi, procfile, "full");
-  *(starvation + 1) = psi.total - total;
-  dbg ("delta (over %lusec) for full: %llu (%llu - %llu)\n",
-       delay, *(starvation + 1), psi.total, total);
+  *(starvation + 1) = (psi.total - total) / delay;
+  dbg ("delta (over %lusec) for full: %llu ((%llu - %llu) / %lu)\n",
+       delay, *(starvation + 1), psi.total, total, delay);
 
   return 0;
 }


### PR DESCRIPTION
Display values per second regardless of the delay, and ensure the delta of "some" is calculated correctly.