### PR TITLE
packages: add support for CentOS Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ List of the Linux kernels that have been successfully tested:
 
 The Nagios Plugins Linux are regularly tested on
  * Alpine Linux (musl libc),
- * Debian, CentOS, Fedora, Gentoo, and Ubuntu (GNU C Library (glibc)).
+ * Debian, Fedora, Gentoo, and Ubuntu (GNU C Library (glibc)).
 
-## Alpine, CentOS/RHEL, Debian, and Fedora Packages
+## Alpine, CentOS Stream, Debian, and Fedora Packages
 
 The `.apk`, `.rpm` and `.deb` packages for Alpine, CentOS/RHEL, Debian, and Fedora can be built using the following commands
 
@@ -130,10 +130,8 @@ Command              | Distribution
 Alpine 3.15          | `make -C packages alpine-3.15`
 Alpine 3.14          | `make -C packages alpine-3.14`
 Alpine 3.13          | `make -C packages alpine-3.13`
-CentOS 5             | `make -C packages centos-5`
-CentOS 6             | `make -C packages centos-6`
-CentOS 7             | `make -C packages centos-7`
-CentOS 8             | `make -C packages centos-8`
+CentOS Stream 8      | `make -C packages centos-stream-8`
+CentOS Stream 9      | `make -C packages centos-stream-9`
 Debian 9 (Stretch)   | `make -C packages debian-stretch`
 Debian 10 (Buster)   | `make -C packages debian-buster`
 Debian 11 (Bullseye) | `make -C packages debian-bullseye`

--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -38,6 +38,10 @@ TARGETS_ALPINE = \
 	alpine-3.15
 alpine-latest: alpine-3.15
 
+TARGETS_CENTOS_STREAM = \
+	centos-stream-8 centos-stream-9
+centos-stream-latest: centos-stream-9
+
 TARGETS_DEBIAN = \
 	debian-stretch debian-buster debian-bullseye
 debian-9: debian-stretch
@@ -46,10 +50,8 @@ debian-11: debian-bullseye
 debian-latest: debian-bullseye
 
 TARGETS_REDHAT = \
-	centos-5 centos-6 centos-7 centos-8 \
 	fedora-33 fedora-34 fedora-35 \
 	fedora-rawhide
-centos-latest: centos-8
 fedora-latest: fedora-35
 
 .PHONY: specfile
@@ -64,6 +66,12 @@ $(TARGETS_ALPINE): specfile source-archive $(DOCKER) $(MULTIBUILD_SCRIPT)
 	@distr=`echo $@ | sed s/-/:/`; \
 	$(SHELL) $(MULTIBUILD_SCRIPT) $(MULTIBUILD_OPTS) \
 	   --spec $(multibuilddir)/specs/APKBUILD \
+	   --os $$distr --target pcks/$@
+
+$(TARGETS_CENTOS_STREAM): specfile source-archive $(DOCKER) $(MULTIBUILD_SCRIPT)
+	@distr=`echo $@ | sed s/centos-stream-//\;s~^~docker.io/tgagor/centos:stream~`; \
+	$(SHELL) $(MULTIBUILD_SCRIPT) $(MULTIBUILD_OPTS) \
+	   --spec $(multibuilddir)/specs/$(SPECFILE) \
 	   --os $$distr --target pcks/$@
 
 $(TARGETS_DEBIAN): source-archive $(DOCKER) $(MULTIBUILD_SCRIPT)

--- a/packages/multibuild.sh
+++ b/packages/multibuild.sh
@@ -139,10 +139,9 @@ case "$os" in
    centos-*)
       pck_format="rpm"
       pck_install="yum install -y"
-      pck_dist=".el${os:7:1}"
-      pcks_dev="bzip2 make gcc libcurl-devel xz rpm-build"
-      # requires libcurl-devel 7.40.0+ which is not available in < CentOS 8
-      case "$os" in centos-8.*) have_libcurl="1" ;; *) have_libcurl="0" ;; esac
+      pck_dist=".elr"
+      pcks_dev="bzip2 make gcc libcurl-devel rpm-build util-linux xz"
+      have_libcurl="1"
       have_libvarlink="0"
    ;;
    debian-*)


### PR DESCRIPTION
Support packaging for CentOS Stream version 8 and 9, now
that CentOS 8 died a premature death.

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>