### PR TITLE
configure: update to autoconf 2.71

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -16,10 +16,18 @@ jobs:
       fail-fast: false
       matrix:
         container:
+          - 'alpine:3.13'
+          - 'alpine:3.14'
           - 'alpine:3.15'
+          - 'debian:9'
+          - 'debian:10'
           - 'debian:11'
+          - 'fedora:34'
+          - 'fedora:35'
           - 'fedora:36'
+          - 'ubuntu:20.04'
           - 'ubuntu:21.10'
+          - 'ubuntu:22.04'
 
     steps:
       - uses: actions/checkout@v2

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ m4_ifndef([LT_INIT], [
 # 'AC_PROG_CC_C99' unfortunately requires autoconf 2.60+
 #AC_PROG_CC_C99
 AM_PROG_CC_C_O
-AC_PROG_CC_STDC
+AC_PROG_CC
 
 if test "$cross_compiling" = no; then
   if test "x$ac_cv_prog_cc_c99" = "xno" || test "x$ac_cv_prog_cc_c99" = "x"; then
@@ -226,7 +226,6 @@ AC_DEFINE_UNQUOTED(
   [Define this if the compiler supports the format printf attribute])
 
 dnl Checks for header files
-AC_HEADER_STDC
 AC_HEADER_STDBOOL
 AC_CHECK_HEADERS([ \
   arpa/inet.h \


### PR DESCRIPTION
Fix the warnings:

  configure.ac:52: warning: The macro `AC_PROG_CC_STDC' is obsolete.
  configure.ac:52: You should run autoupdate.
  ./lib/autoconf/c.m4:1666: AC_PROG_CC_STDC is expanded from...
  configure.ac:52: the top level
  configure.ac:229: warning: The macro `AC_HEADER_STDC' is obsolete.
  configure.ac:229: You should run autoupdate.
  ./lib/autoconf/headers.m4:704: AC_HEADER_STDC is expanded from...
  configure.ac:229: the top level

Announcements:
 - https://lists.gnu.org/archive/html/autotools-announce/2020-12/msg00001.html
 - https://lists.gnu.org/archive/html/autotools-announce/2021-01/msg00000.html

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>