### PR TITLE
filecount: new cmdline option --name

### DIFF
--- a/include/files.h
+++ b/include/files.h
@@ -34,7 +34,7 @@ extern "C"
   };
 
   int files_filecount (const char *dir, unsigned int flags,
-		       int64_t age, int64_t size);
+		       int64_t age, int64_t size, const char *pattern);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Only count files that match PATTERN, where PATTERN is a shell-like  " wildcard" as understood by fnmatch(3).

Signed-off-by: Davide Madrisan <d.madrisan@qwant.com>