### PR TITLE
bug#112: fix an issue reported by clang-analyzer

### DIFF
--- a/lib/container_docker_memory.c
+++ b/lib/container_docker_memory.c
@@ -88,7 +88,6 @@ docker_memory_desc_read (struct docker_memory_desc *__restrict memdesc)
   char *line = NULL;
   FILE *fp;
   size_t len = 0;
-  ssize_t chread;
 
   char *syspath = get_docker_memory_stat_path ();
 
@@ -99,7 +98,7 @@ docker_memory_desc_read (struct docker_memory_desc *__restrict memdesc)
     plugin_error (STATE_UNKNOWN, errno, "error opening %s", syspath);
 
   dbg ("parsing the file \"%s\"...\n", syspath);
-  while ((chread = getline (&line, &len, fp)) != -1)
+  while (getline (&line, &len, fp) != -1)
     {
       dbg ("line: %s", line);
 


### PR DESCRIPTION
Fix the following issue:

    In file included from tslibcontainer_docker_memory.c:37:
    ./../lib/container_docker_memory.c:102:11: warning: Although the value
    stored to 'chread' is used in the enclosing expression, the value is
    never actually read from 'chread' [deadcode.DeadStores]
      while ((chread = getline (&line, &len, fp)) != -1)
              ^        ~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Davide Madrisan <d.madrisan@qwant.com>