### PR TITLE
configure: do not silently ignore missing libcurl and libvarlink

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -52,7 +52,15 @@ jobs:
       - id: configure
         run: |
           autoreconf --install
-          ./configure --enable-debug
+          case "${{ matrix.container }}" in
+            alpine*|debian*|ubuntu*)
+              ./configure --enable-libcurl --enable-debug
+            ;;
+            # libvarlink is only available in Fedora
+            *)
+              ./configure --enable-libcurl --enable-libvarlink --enable-debug
+            ;;
+          esac
 
       - id: make
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -338,9 +338,9 @@ AC_CHECK_DECLS([CPU_ALLOC], [], [],
 dnl Check for libcurl
 AC_ARG_ENABLE([libcurl],
   AS_HELP_STRING([--disable-libcurl], [Disable libcurl]))
-AS_IF([test "x$enable_libcurl" != "xno"], [
-  LIBCURL_CHECK_CONFIG([], 7.40.0, [],
-    [AC_MSG_WARN([Missing required libcurl >= 7.40.0])])
+AS_IF([test "x$enable_libcurl" = "xyes"], [
+  LIBCURL_CHECK_CONFIG([], [7.40.0], [],
+    [AC_MSG_ERROR([Missing required libcurl >= 7.40.0])])
   AC_SUBST([LIBCURL_CPPFLAGS])
   AC_SUBST([LIBCURL])
   AM_CONDITIONAL(HAVE_LIBCURL, [test "$libcurl_cv_lib_curl_usable" = "yes"])
@@ -349,13 +349,13 @@ AS_IF([test "x$enable_libcurl" != "xno"], [
 dnl Check for libvarlink
 AC_ARG_ENABLE([libvarlink],
   AS_HELP_STRING([--disable-libvarlink], [Disable libvarlink]))
-AS_IF([test "x$enable_libvarlink" != "xno"], [
+AS_IF([test "x$enable_libvarlink" = "xyes"], [
   PKG_CHECK_EXISTS([libvarlink],
     [PKG_CHECK_MODULES(LIBVARLINK, [libvarlink >= 18],
       [AC_DEFINE(HAVE_LIBVARLINK, 1, [Define if libvarlink is available])
        have_libvarlink=yes],
-      AC_MSG_ERROR([*** libvarlink version 18 or better not found]))])
-])
+      [AC_MSG_ERROR([*** libvarlink version 18 or better not found])])],
+    [AC_MSG_ERROR([*** libvarlink not found])])])
 AM_CONDITIONAL(HAVE_LIBVARLINK, [test "$have_libvarlink" = "yes"])
 
 dnl Check for the procps newlib
@@ -566,18 +566,23 @@ echo "  LDFLAGS            = $LDFLAGS"
 echo
 
 if test "$have_libprocps" = "yes"; then
+  echo "Optional procps-ng library support is enabled:"
   echo "  LIBPROCPS_CFLAGS   = $LIBPROCPS_CFLAGS"
   echo "  LIBPROCPS_LIBS     = $LIBPROCPS_LIBS"
   echo
 fi
 
 if test "$libcurl_cv_lib_curl_usable" = "yes"; then
+  echo "Optional curl library support is enabled (required by check_docker):"
   echo "  LIBCURL_CPPFLAGS   = $LIBCURL_CPPFLAGS"
   echo "  LIBCURL            = $LIBCURL"
   echo
 fi
 
 if test "$have_libvarlink" = "yes"; then
+  echo "Optional varlink library support is enabled (required by check_podman):"
+  echo "  LIBVARLINK_CFLAGS  = $LIBVARLINK_CFLAGS"
+  echo "  LIBVARLINK_LIBS    = -lvarlink"
   echo "  VARLINK_ADDRESS    = $VARLINK_ADDRESS"
   echo
 fi


### PR DESCRIPTION
Exit with an error message when:
 * libvarlink is not available and the option --enable-libvarlink is used
 * libcurl is not available and the option --enable-libcurl is used because in this case libcurl/libvarlink support is purposely required.

Bug reported by @sbraz

Signed-off-by: Davide Madrisan <davide.madrisan@gmail.com>