### PR TITLE
lib/netinfo-private: don't enforce nl_pid

### DIFF
--- a/lib/netinfo-private.c
+++ b/lib/netinfo-private.c
@@ -260,7 +260,7 @@ get_rtnl_fd ()
   memset (&u.local, 0, sizeof (u.local));
   u.local.nl_family = AF_NETLINK;
   u.local.nl_groups = 0;
-  u.local.nl_pid = getpid ();
+  u.local.nl_pid = 0;
 
   if (bind (fd, &u.addr, sizeof (u.addr)) < 0)
     {


### PR DESCRIPTION
Fixes: https://github.com/madrisan/nagios-plugins-linux/issues/126

The `bind()` call can fail when `getpid()` is used as `nl_pid`, application is containerized and host network is used because process ids are not unique between host and container environments.  
When 0 is used as `nl_pid` it's up to kernel to assign netlink address.

This fix is currently tested in our environment. I will ping you if it fixes issue.