### PR TITLE
check_users: fix an issue related to the Y2038 unix bug

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -45,7 +45,7 @@ jobs:
             ;;
             fedora*)
               dnf -y update
-              dnf -y install autoconf automake bzip2 gcc glibc-devel libcurl-devel libvarlink-devel libtool make m4 systemd-devel xz
+              dnf -y install autoconf automake bzip2 diffutils gcc glibc-devel libcurl-devel libvarlink-devel libtool make m4 systemd-devel xz
             ;;
           esac
 

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -41,11 +41,11 @@ jobs:
             debian*|ubuntu*)
               export DEBIAN_FRONTEND=noninteractive
               apt-get update -q
-              apt-get install -q -y --no-install-recommends autoconf automake bzip2 gcc libcurl4-gnutls-dev libtool m4 make pkg-config xz-utils
+              apt-get install -q -y --no-install-recommends autoconf automake bzip2 gcc libcurl4-gnutls-dev libsystemd-dev libtool m4 make pkg-config xz-utils
             ;;
             fedora*)
               dnf -y update
-              dnf -y install autoconf automake bzip2 gcc glibc-devel libcurl-devel libvarlink-devel libtool make m4 xz
+              dnf -y install autoconf automake bzip2 gcc glibc-devel libcurl-devel libvarlink-devel libtool make m4 systemd-devel xz
             ;;
           esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -346,6 +346,24 @@ AS_IF([test "x$enable_libcurl" = "xyes"], [
   AM_CONDITIONAL(HAVE_LIBCURL, [test "$libcurl_cv_lib_curl_usable" = "yes"])
 ], [AM_CONDITIONAL(HAVE_LIBCURL, false)])
 
+dnl Check for systemd-login libraries
+AC_ARG_WITH([systemd],
+  AS_HELP_STRING([--without-systemd], [do not build with systemd support]),
+  [], [with_systemd=check]
+)
+have_systemd=no
+AS_IF([test "x$with_systemd" != "xno"], [
+  PKG_CHECK_MODULES([SYSTEMD], [libsystemd], [have_systemd=yes], [have_systemd=no])
+  AS_CASE([$with_systemd:$have_systemd],
+    [yes:no],
+      [AC_MSG_ERROR([systemd expected but libsystemd not found])],
+    [*:yes],
+       AC_DEFINE([HAVE_LIBSYSTEMD], [1], [Define if libsystemd is available])
+       AC_DEFINE([USE_SYSTEMD], [1], [Define if systemd support is wanted ])
+  )
+])
+AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$have_systemd" = "xyes"])
+
 dnl Check for libvarlink
 AC_ARG_ENABLE([libvarlink],
   AS_HELP_STRING([--disable-libvarlink], [Disable libvarlink]))


### PR DESCRIPTION
It seems that the glibc developers don't want to fix the year 2038 problem in the utmp.h/utmpx.h/lastlog.h interfaces but prefer to deprecate them, so prefer the analogous functionality provided by systemd when available.