### PR TITLE
lib/netinfo-private: fix Clang 17 warning

### DIFF
--- a/lib/netinfo-private.c
+++ b/lib/netinfo-private.c
@@ -135,8 +135,8 @@ check_link_speed (const char *ifname, uint32_t *speed, uint8_t *duplex)
 #ifdef ETHTOOL_GLINKSETTINGS
 # define ETHTOOL_LINK_MODE_MASK_MAX_KERNEL_NU32  (SCHAR_MAX)
   struct elinkset {
-    struct ethtool_link_settings req;
     uint32_t link_mode_data[3 * ETHTOOL_LINK_MODE_MASK_MAX_KERNEL_NU32];
+    struct ethtool_link_settings req;
   } elinkset;
 #endif
 


### PR DESCRIPTION
      CC       netinfo-private.o
    netinfo-private.c:138:34: warning: field 'req' with variable sized type
    'struct ethtool_link_settings' not at the end of a struct or class is a
    GNU extension [-Wgnu-variable-sized-type-not-at-end]
      138 |     struct ethtool_link_settings req;
          |                                  ^
    1 warning generated.