### PR TITLE
Fix Icinga 2 config for check_clock

### DIFF
--- a/contrib/icinga2/CheckCommands.conf
+++ b/contrib/icinga2/CheckCommands.conf
@@ -23,7 +23,7 @@ object CheckCommand "madrisan-clock" {
 	arguments += {
 		"-r" = {
 			description = "the clock reference (in seconds since the Epoch)"
-			value = DateTime().format("%s")
+			value = {{ DateTime().format("%s") }}
 		}
 		"-w" = {
 			description = "Warning threshold"


### PR DESCRIPTION
Previously the time reference value was evaluated only during the startup of Icinga 2 and therefore a fixed point in time.

This change makes it a function which gets evaluated every time the check is executed.